### PR TITLE
Manage volatile locks using OSAtomic.h functions

### DIFF
--- a/jre_emul/Classes/J2ObjC_common.m
+++ b/jre_emul/Classes/J2ObjC_common.m
@@ -18,6 +18,8 @@
 
 #import "J2ObjC_common.h"
 
+#import <libkern/OSAtomic.h>
+
 #import "FastPointerLookup.h"
 #import "IOSClass.h"
 #import "java/lang/AbstractStringBuilder.h"
@@ -92,9 +94,9 @@ id JreStrongAssignAndConsume(__strong id *pIvar, NS_RELEASES_ARGUMENT id value) 
 #define VOLATILE_MASK ((1 << VOLATILE_POWER) - 1)
 #define VOLATILE_HASH(x) (((long)x >> 5) & VOLATILE_MASK)
 #define VOLATILE_GETLOCK(ptr) &volatile_locks[VOLATILE_HASH(ptr)]
-#define VOLATILE_LOCK(l) while (__c11_atomic_exchange(l, 1, __ATOMIC_SEQ_CST)) {}
-#define VOLATILE_UNLOCK(l) __c11_atomic_store(l, 0, __ATOMIC_SEQ_CST)
-typedef _Atomic(uint8_t) volatile_lock_t;
+#define VOLATILE_LOCK(l) OSSpinLockLock(l)
+#define VOLATILE_UNLOCK(l) OSSpinLockUnlock(l)
+typedef OSSpinLock volatile_lock_t;
 static volatile_lock_t volatile_locks[1 << VOLATILE_POWER] = { 0 };
 
 id JreLoadVolatileId(volatile_id *pVar) {


### PR DESCRIPTION
We are having a problem in our application because we are using a ConcurrentLinkedQueue which is internally using `volatile` variables.

The translated code was using custom made _spin-lock_ mechanism to acquire the lock on the variable pointer without yelding control to other threads after a certain amount of time.

This is a problem when the main thread is waiting on a lock acquired by a background thread with lower priority: the background thread wich has acquired the lock was never allowed some CPU time to release the lock.

By using OSAtomic function for _spin-lock_, the main thread should yield control over other threads. However, there may still have a problem with this solution since the introduction of the new Threading Scheduler using QOS, the problem may still arise. Will see...

Reference:
http://engineering.postmates.com/Spinlocks-Considered-Harmful-On-iOS/


