### PR TITLE
Fix determining param names for kotlin when it is a Generic

### DIFF
--- a/kotlin-native-tests/src/test/java/InterfacesTests.java
+++ b/kotlin-native-tests/src/test/java/InterfacesTests.java
@@ -28,4 +28,10 @@ public class InterfacesTests extends TestCase {
         assert (list.get(0) == Integer.valueOf(1));
     }
 
+    @Test
+    public void testInterfaceWithGenerics() {
+        WithGenerics withGenerics = new WithGenerics();
+        assert (withGenerics.main(args) == Integer.valueOf(5));
+    }
+
 }

--- a/translator/src/main/java/com/google/devtools/j2objc/util/NameTable.java
+++ b/translator/src/main/java/com/google/devtools/j2objc/util/NameTable.java
@@ -959,7 +959,19 @@ public class NameTable {
   private String toJavaType(KmType kmType,
                             List<KmTypeParameter> kmClassTypeParameters) {
     boolean isNullable = Type.IS_NULLABLE.invoke(kmType.getFlags());
-    String kotlinType = ((KmClassifier.Class) kmType.getClassifier()).getName();
+
+    KmClassifier classifier = kmType.getClassifier();
+    String kotlinType;
+    if (classifier instanceof KmClassifier.Class) {
+      kotlinType = ((KmClassifier.Class) classifier).getName();
+    } else if (classifier instanceof  KmClassifier.TypeAlias) {
+      kotlinType = ((KmClassifier.TypeAlias) classifier).getName();
+    } else if (classifier instanceof  KmClassifier.TypeParameter) {
+      int typeId = ((KmClassifier.TypeParameter) classifier).getId();
+      kotlinType = kmClassTypeParameters.get(typeId).getName();
+    } else {
+      throw new RuntimeException(String.format("Unsupported Kotlin KmClassifier : %s", classifier.getClass().getSimpleName()));
+    }
 
     String javaType = null;
     if (isKotlinType(kotlinType)) {

--- a/translator/src/main/java/com/google/devtools/j2objc/util/NameTable.java
+++ b/translator/src/main/java/com/google/devtools/j2objc/util/NameTable.java
@@ -964,9 +964,9 @@ public class NameTable {
     String kotlinType;
     if (classifier instanceof KmClassifier.Class) {
       kotlinType = ((KmClassifier.Class) classifier).getName();
-    } else if (classifier instanceof  KmClassifier.TypeAlias) {
+    } else if (classifier instanceof KmClassifier.TypeAlias) {
       kotlinType = ((KmClassifier.TypeAlias) classifier).getName();
-    } else if (classifier instanceof  KmClassifier.TypeParameter) {
+    } else if (classifier instanceof KmClassifier.TypeParameter) {
       int typeId = ((KmClassifier.TypeParameter) classifier).getId();
       kotlinType = kmClassTypeParameters.get(typeId).getName();
     } else {

--- a/translator/src/test/java/com/google/devtools/j2objc/kotlin/InterfacesTest.java
+++ b/translator/src/test/java/com/google/devtools/j2objc/kotlin/InterfacesTest.java
@@ -1,6 +1,7 @@
 package com.google.devtools.j2objc.kotlin;
 
 import com.google.devtools.j2objc.GenerationTest;
+import com.mirego.interop.java.test.interfaces.WithGenerics;
 import com.mirego.interop.java.test.interfaces.WithInt;
 import com.mirego.interop.java.test.interfaces.WithList;
 import com.mirego.interop.java.test.interfaces.WithNullableInt;
@@ -46,6 +47,15 @@ public class InterfacesTest extends GenerationTest {
     assertTranslation(translation, "- (id<JavaUtilList>)convertInputList:(id<JavaUtilList>)inputList {\n"
         + "  return inputList;\n"
         + "}");
+  }
+
+  @Test
+  public void testInterfaceWithGenerics() throws IOException {
+
+    String className = WithGenerics.class.getSimpleName();
+    String translation = translateJavaSourceFileForKotlinTest(className, testPackage, ".m");
+
+    assertTranslation(translation, "return [((JavaLangInteger *) nil_chk([((id<CommonInterfaceWithGenerics>) nil_chk(process)) convertInput:JavaLangInteger_valueOfWithInt_(5)])) intValue];");
   }
 
 }


### PR DESCRIPTION
We were not taking into account the various variant a parameter could be i.e. Class, Type or TypeAlias when trying to find it's name. We now take this into account.

Added unit test that validate the code generated and the behavior at runtime.