### PR TITLE
Support Function Generic, Fix switch cases and remove test Submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "submodules/kotlin-interop-test-cases"]
-	path = submodules/kotlin-interop-test-cases
-	url = git@github.com:mirego/mirego-kotlin-interop-test-cases.git

--- a/kotlin-interop-test-cases/src/commonMain/kotlin
+++ b/kotlin-interop-test-cases/src/commonMain/kotlin
@@ -1,1 +1,0 @@
-../../../submodules/kotlin-interop-test-cases/kotlin

--- a/kotlin-interop-test-cases/src/commonMain/kotlin/test/constructor/ClassWithConstructorWithIntParameter.kt
+++ b/kotlin-interop-test-cases/src/commonMain/kotlin/test/constructor/ClassWithConstructorWithIntParameter.kt
@@ -1,0 +1,4 @@
+package com.mirego.interop.kotlin.test.constructor
+
+class ClassWithDefaultConstructorWithIntParameter(val intParameter: Int) {
+}

--- a/kotlin-interop-test-cases/src/commonMain/kotlin/test/constructor/ClassWithConstructorWithListParameter.kt
+++ b/kotlin-interop-test-cases/src/commonMain/kotlin/test/constructor/ClassWithConstructorWithListParameter.kt
@@ -1,0 +1,4 @@
+package com.mirego.interop.kotlin.test.constructor
+
+class ClassWithDefaultConstructorWithListParameter<E>(val listParameter: List<E>) {
+}

--- a/kotlin-interop-test-cases/src/commonMain/kotlin/test/constructor/ClassWithConstructorWithMutableListParameter.kt
+++ b/kotlin-interop-test-cases/src/commonMain/kotlin/test/constructor/ClassWithConstructorWithMutableListParameter.kt
@@ -1,0 +1,4 @@
+package com.mirego.interop.kotlin.test.constructor
+
+class ClassWithDefaultConstructorWithMutableListParameter<E>(val mutableListParemeter: MutableList<E>) {
+}

--- a/kotlin-interop-test-cases/src/commonMain/kotlin/test/constructor/ClassWithConstructorWithNullableIntParameter.kt
+++ b/kotlin-interop-test-cases/src/commonMain/kotlin/test/constructor/ClassWithConstructorWithNullableIntParameter.kt
@@ -1,0 +1,4 @@
+package com.mirego.interop.kotlin.test.constructor
+
+class ClassWithDefaultConstructorWithNullableIntParameter(val nullableIntParameter: Int?) {
+}

--- a/kotlin-interop-test-cases/src/commonMain/kotlin/test/constructor/ClassWithConstructorWithUserClassParameter.kt
+++ b/kotlin-interop-test-cases/src/commonMain/kotlin/test/constructor/ClassWithConstructorWithUserClassParameter.kt
@@ -1,0 +1,4 @@
+package com.mirego.interop.kotlin.test.constructor
+
+class ClassWithDefaultConstructorWithUserClassParameter(val userClassParameter: ClassWithoutConstructor) {
+}

--- a/kotlin-interop-test-cases/src/commonMain/kotlin/test/constructor/ClassWithDefaultConstructor.kt
+++ b/kotlin-interop-test-cases/src/commonMain/kotlin/test/constructor/ClassWithDefaultConstructor.kt
@@ -1,0 +1,4 @@
+package com.mirego.interop.kotlin.test.constructor
+
+class ClassWithDefaultConstructor(val name: String) {
+}

--- a/kotlin-interop-test-cases/src/commonMain/kotlin/test/constructor/ClassWithDefaultConstructorMultipleParameters.kt
+++ b/kotlin-interop-test-cases/src/commonMain/kotlin/test/constructor/ClassWithDefaultConstructorMultipleParameters.kt
@@ -1,0 +1,4 @@
+package com.mirego.interop.kotlin.test.constructor
+
+class ClassWithDefaultConstructorMultipleParameters(val firstParameter: String, val secondParameter: String,) {
+}

--- a/kotlin-interop-test-cases/src/commonMain/kotlin/test/constructor/ClassWithDefaultConstructorWithDefaultValue.kt
+++ b/kotlin-interop-test-cases/src/commonMain/kotlin/test/constructor/ClassWithDefaultConstructorWithDefaultValue.kt
@@ -1,0 +1,4 @@
+package com.mirego.interop.kotlin.test.constructor
+
+class ClassWithDefaultConstructorWithDefaultValue(val name: String = "DefaultName") {
+}

--- a/kotlin-interop-test-cases/src/commonMain/kotlin/test/constructor/ClassWithDefaultConstructorWithInitBlock.kt
+++ b/kotlin-interop-test-cases/src/commonMain/kotlin/test/constructor/ClassWithDefaultConstructorWithInitBlock.kt
@@ -1,0 +1,7 @@
+package com.mirego.interop.kotlin.test.constructor
+
+class ClassWithDefaultConstructorWithInitBlock(var name: String) {
+    init {
+        name = "nameSetInInitBlock"
+    }
+}

--- a/kotlin-interop-test-cases/src/commonMain/kotlin/test/constructor/ClassWithDefaultConstructorWithMultipleInitBlocks.kt
+++ b/kotlin-interop-test-cases/src/commonMain/kotlin/test/constructor/ClassWithDefaultConstructorWithMultipleInitBlocks.kt
@@ -1,0 +1,13 @@
+package com.mirego.interop.kotlin.test.constructor
+
+class ClassWithDefaultConstructorWithMultipleInitBlocks(var name: String) {
+    init {
+        name = "nameSetInFirstInitBlock"
+    }
+
+    val secondProperty = "secondProperty"
+
+    init {
+        name = "nameSetInSecondInitBlock"
+    }
+}

--- a/kotlin-interop-test-cases/src/commonMain/kotlin/test/constructor/ClassWithDefaultConstructorWithPrivateProperty.kt
+++ b/kotlin-interop-test-cases/src/commonMain/kotlin/test/constructor/ClassWithDefaultConstructorWithPrivateProperty.kt
@@ -1,0 +1,4 @@
+package com.mirego.interop.kotlin.test.constructor
+
+class ClassWithDefaultConstructorWithPrivateProperty(private val name: String) {
+}

--- a/kotlin-interop-test-cases/src/commonMain/kotlin/test/constructor/ClassWithSecondaryConstructor.kt
+++ b/kotlin-interop-test-cases/src/commonMain/kotlin/test/constructor/ClassWithSecondaryConstructor.kt
@@ -1,0 +1,5 @@
+package com.mirego.interop.kotlin.test.constructor
+
+class ClassWithSecondaryConstructor(val name: String) {
+    constructor() : this("ClassWithSecondaryConstructor")
+}

--- a/kotlin-interop-test-cases/src/commonMain/kotlin/test/constructor/ClassWithoutConstructor.kt
+++ b/kotlin-interop-test-cases/src/commonMain/kotlin/test/constructor/ClassWithoutConstructor.kt
@@ -1,0 +1,5 @@
+package com.mirego.interop.kotlin.test.constructor
+
+class ClassWithoutConstructor {
+    val name: String = "ClassWithoutConstructor"
+}

--- a/kotlin-interop-test-cases/src/commonMain/kotlin/test/dataclass/MutableDataClass.kt
+++ b/kotlin-interop-test-cases/src/commonMain/kotlin/test/dataclass/MutableDataClass.kt
@@ -1,0 +1,3 @@
+package com.mirego.interop.kotlin.test.dataclass
+
+data class MutableDataClass(var name: String, var number: Int)

--- a/kotlin-interop-test-cases/src/commonMain/kotlin/test/dataclass/SimpleDataClass.kt
+++ b/kotlin-interop-test-cases/src/commonMain/kotlin/test/dataclass/SimpleDataClass.kt
@@ -1,0 +1,3 @@
+package com.mirego.interop.kotlin.test.dataclass
+
+data class SimpleDataClass(val name:String, val number:Int)

--- a/kotlin-interop-test-cases/src/commonMain/kotlin/test/enums/EnumWithProperty.kt
+++ b/kotlin-interop-test-cases/src/commonMain/kotlin/test/enums/EnumWithProperty.kt
@@ -1,0 +1,6 @@
+package com.mirego.interop.kotlin.test.enums
+
+enum class EnumWithProperty(val content: String) {
+    ENUMVALUE1("ENUMVALUE1_TEST"),
+    ENUMVALUE2("ENUMVALUE2_TEST")
+}

--- a/kotlin-interop-test-cases/src/commonMain/kotlin/test/enums/SimpleEnum.kt
+++ b/kotlin-interop-test-cases/src/commonMain/kotlin/test/enums/SimpleEnum.kt
@@ -1,0 +1,5 @@
+package com.mirego.interop.kotlin.test.enums
+
+enum class SimpleEnum {
+    ENUMVALUE1, ENUM_VALUE2, ENUM_VALUE_3
+}

--- a/kotlin-interop-test-cases/src/commonMain/kotlin/test/function/ClassWithPublicFunctionReturningUnit.kt
+++ b/kotlin-interop-test-cases/src/commonMain/kotlin/test/function/ClassWithPublicFunctionReturningUnit.kt
@@ -1,0 +1,5 @@
+package com.mirego.interop.kotlin.test.function
+
+public class ClassWithPublicFunctionReturningUnit() {
+    public fun returnUnit() {}
+}

--- a/kotlin-interop-test-cases/src/commonMain/kotlin/test/function/ClassWithPublicFunctions.kt
+++ b/kotlin-interop-test-cases/src/commonMain/kotlin/test/function/ClassWithPublicFunctions.kt
@@ -1,0 +1,120 @@
+package com.mirego.interop.kotlin.test.function
+
+import kotlin.js.JsName
+import kotlin.jvm.JvmOverloads
+
+public class ClassWithPublicFunctions() {
+
+    companion object {
+        public fun staticReturnString(): String {
+            return "staticString"
+        }
+    }
+
+    public fun returnUnit() {}
+
+    public fun returnShort(): Short {
+        return 1.toShort()
+    }
+
+    public fun returnString(): String {
+        return "testString"
+    }
+
+    public fun returnInt(): Int {
+        return 1
+    }
+
+    public fun returnLong(): Long {
+        return 1
+    }
+
+    public fun returnBoolean(): Boolean {
+        return false
+    }
+
+    public fun returnCharacter(): Char {
+        return 'a'
+    }
+
+    public fun returnFloat(): Float {
+        return 1.0f
+    }
+
+    public fun returnDouble(): Double {
+        return 1.0
+    }
+
+    @JsName("withDefaultArguments")
+    @JvmOverloads
+    public fun withDefaultArguments(string1: String, string2: String = "argument"): String {
+        return string1 + " " + string2
+    }
+
+    public fun singleExpression() = "single expression"
+
+    public fun localFunction(): String {
+        var testString = ""
+        fun concatInput(input: String): String {
+            return testString.plus(input)
+        }
+        testString = concatInput("local")
+        return concatInput(" function")
+    }
+
+    @JsName("variableArgumentsSum")
+    public fun variableArgumentsSum(vararg numbers: Int): Int {
+        var result = 0
+        for (number in numbers) {
+            result += number
+        }
+        return result
+    }
+
+    @JsName("recursiveFunction")
+    public fun recursiveFunction(number: Int): Long {
+        if (number == 1) {
+            return number.toLong()
+        } else {
+            return number * recursiveFunction(number - 1)
+        }
+    }
+
+    @JsName("tailRecursiveFunction")
+    public tailrec fun tailRecursiveFunction(n: Int, accum: Long): Long {
+        val soFar = n.toLong() * accum
+        return if (n <= 1) {
+            soFar
+        } else {
+            tailRecursiveFunction(n - 1, soFar)
+        }
+    }
+
+    val lambdaFunction = { number: Int -> number * number }
+
+    public fun String.removeFirstChar(): String = this.substring(1, this.length)
+
+    @JsName("extensionFunction")
+    public fun extensionFunction(string: String): String {
+        return string.removeFirstChar()
+    }
+
+    private inner class InnerClass {
+        public fun sum(number1: Int, number2: Int): Int {
+            return number1 + number2
+        }
+    }
+
+    @JsName("innerClassFunction")
+    public fun innerClassFunction(number1: Int, number2: Int): Int {
+        return InnerClass().sum(number1, number2)
+    }
+
+    public fun overloadedFunction(number: Int): String {
+        return overloadedFunction(number.toString())
+    }
+
+    public fun overloadedFunction(string: String): String {
+        return string
+    }
+}

--- a/kotlin-interop-test-cases/src/commonMain/kotlin/test/interfaces/InterfaceWithGenerics.kt
+++ b/kotlin-interop-test-cases/src/commonMain/kotlin/test/interfaces/InterfaceWithGenerics.kt
@@ -2,4 +2,8 @@ package com.mirego.interop.kotlin.test.interfaces
 
 interface InterfaceWithGenerics<T, U> {
     fun convert(input: T): U
+
+    fun <V> convertWithFunctionGeneric(otherInput: V): V
+
+    fun <W> convertWithAnotherFunctionGeneric(anotherInput: W): W
 }

--- a/kotlin-interop-test-cases/src/commonMain/kotlin/test/interfaces/InterfaceWithGenerics.kt
+++ b/kotlin-interop-test-cases/src/commonMain/kotlin/test/interfaces/InterfaceWithGenerics.kt
@@ -1,0 +1,5 @@
+package com.mirego.interop.kotlin.test.interfaces
+
+interface InterfaceWithGenerics<T, U> {
+    fun convert(input: T): U
+}

--- a/kotlin-interop-test-cases/src/commonMain/kotlin/test/interfaces/InterfaceWithInt.kt
+++ b/kotlin-interop-test-cases/src/commonMain/kotlin/test/interfaces/InterfaceWithInt.kt
@@ -1,0 +1,5 @@
+package com.mirego.interop.kotlin.test.interfaces
+
+interface InterfaceWithInt {
+    fun convert(inputInt: Int) : Int
+}

--- a/kotlin-interop-test-cases/src/commonMain/kotlin/test/interfaces/InterfaceWithList.kt
+++ b/kotlin-interop-test-cases/src/commonMain/kotlin/test/interfaces/InterfaceWithList.kt
@@ -1,0 +1,5 @@
+package com.mirego.interop.kotlin.test.interfaces
+
+interface InterfaceWithList<E> {
+    fun convert(inputList: List<E>) : List<E>
+}

--- a/kotlin-interop-test-cases/src/commonMain/kotlin/test/interfaces/InterfaceWithNullableInt.kt
+++ b/kotlin-interop-test-cases/src/commonMain/kotlin/test/interfaces/InterfaceWithNullableInt.kt
@@ -1,0 +1,5 @@
+package com.mirego.interop.kotlin.test.interfaces
+
+interface InterfaceWithNullableInt {
+    fun convert(inputNullableInt: Int?) : Int?
+}

--- a/kotlin-interop-test-cases/src/commonMain/kotlin/test/nullsafety/ClassForNullSafety.kt
+++ b/kotlin-interop-test-cases/src/commonMain/kotlin/test/nullsafety/ClassForNullSafety.kt
@@ -1,0 +1,8 @@
+package com.mirego.interop.kotlin.test.nullsafety
+
+public class ClassForNullSafety() {
+    public fun doubleBang(): String {
+        val a: String? = null
+        return a!!
+    }
+}

--- a/kotlin-interop-test-cases/src/commonMain/kotlin/test/objects/ObjectWithMethod.kt
+++ b/kotlin-interop-test-cases/src/commonMain/kotlin/test/objects/ObjectWithMethod.kt
@@ -19,4 +19,9 @@ object ObjectWithMethod {
     fun staticMethodWithListParamWithAnnotation(input: List<Int>): List<Int> {
         return input
     }
+
+    @JvmStatic
+    fun <T> staticMethodWithGenericParam(input: T): T {
+        return input
+    }
 }

--- a/kotlin-interop-test-cases/src/commonMain/kotlin/test/objects/ObjectWithMethod.kt
+++ b/kotlin-interop-test-cases/src/commonMain/kotlin/test/objects/ObjectWithMethod.kt
@@ -1,0 +1,22 @@
+package com.mirego.interop.kotlin.test.objects
+
+import kotlin.jvm.JvmStatic
+import kotlin.js.JsName
+
+object ObjectWithMethod {
+    @JvmStatic
+    fun staticMethodWithoutParamWithAnnotation(): String {
+        return "return"
+    }
+
+    @JvmStatic
+    @JsName("staticMethodWithStringParamWithAnnotation")
+    fun staticMethodWithStringParamWithAnnotation(input: String): String {
+        return input
+    }
+
+    @JvmStatic
+    fun staticMethodWithListParamWithAnnotation(input: List<Int>): List<Int> {
+        return input
+    }
+}

--- a/kotlin-interop-test-cases/src/commonMain/kotlin/test/property/ClassWithArrayProperty.kt
+++ b/kotlin-interop-test-cases/src/commonMain/kotlin/test/property/ClassWithArrayProperty.kt
@@ -1,0 +1,7 @@
+package com.mirego.interop.kotlin.test.property
+
+import kotlin.js.JsName
+
+class ClassWithArrayProperty() {
+    val array = arrayOf("FirstElement")
+}

--- a/kotlin-interop-test-cases/src/commonMain/kotlin/test/property/ClassWithBackingFieldCustomGetter.kt
+++ b/kotlin-interop-test-cases/src/commonMain/kotlin/test/property/ClassWithBackingFieldCustomGetter.kt
@@ -1,0 +1,10 @@
+package com.mirego.interop.kotlin.test.property
+
+import kotlin.js.JsName
+
+class ClassWithBackingFieldCustomGetter() {
+    val backedField = "backed"
+        get() {
+            return field.plus(" field")
+        }
+}

--- a/kotlin-interop-test-cases/src/commonMain/kotlin/test/property/ClassWithBackingFieldCustomSetter.kt
+++ b/kotlin-interop-test-cases/src/commonMain/kotlin/test/property/ClassWithBackingFieldCustomSetter.kt
@@ -1,0 +1,10 @@
+package com.mirego.interop.kotlin.test.property
+
+import kotlin.js.JsName
+
+class ClassWithBackingFieldCustomSetter() {
+    var backedField = "defaultBackedField"
+        set(value) {
+            field = value.plus(" field")
+        }
+}

--- a/kotlin-interop-test-cases/src/commonMain/kotlin/test/property/ClassWithBackingPropertyCustomGetter.kt
+++ b/kotlin-interop-test-cases/src/commonMain/kotlin/test/property/ClassWithBackingPropertyCustomGetter.kt
@@ -1,0 +1,12 @@
+package com.mirego.interop.kotlin.test.property
+
+import kotlin.js.JsName
+
+class ClassWithBackingPropertyCustomGetter() {
+    private val _backedProperty = "backed"
+
+    val backedProperty: String
+        get() {
+            return _backedProperty.plus(" property")
+        }
+}

--- a/kotlin-interop-test-cases/src/commonMain/kotlin/test/property/ClassWithBackingPropertyCustomSetter.kt
+++ b/kotlin-interop-test-cases/src/commonMain/kotlin/test/property/ClassWithBackingPropertyCustomSetter.kt
@@ -1,0 +1,17 @@
+package com.mirego.interop.kotlin.test.property
+
+import kotlin.js.JsName
+
+class ClassWithBackingPropertyCustomSetter() {
+    private var _backedProperty = "defaultBackedProperty"
+
+    @get:JsName("getBackedProperty")
+    @set:JsName("setBackedProperty")
+    public var backedProperty: String
+        get() {
+            return _backedProperty
+        }
+        set(value) {
+            _backedProperty = value
+        }
+}

--- a/kotlin-interop-test-cases/src/commonMain/kotlin/test/property/ClassWithBooleanProperty.kt
+++ b/kotlin-interop-test-cases/src/commonMain/kotlin/test/property/ClassWithBooleanProperty.kt
@@ -1,0 +1,7 @@
+package com.mirego.interop.kotlin.test.property
+
+import kotlin.js.JsName
+
+class ClassWithBooleanProperty(booleanProperty: Boolean) {
+    val booleanProperty = booleanProperty
+}

--- a/kotlin-interop-test-cases/src/commonMain/kotlin/test/property/ClassWithByteProperty.kt
+++ b/kotlin-interop-test-cases/src/commonMain/kotlin/test/property/ClassWithByteProperty.kt
@@ -1,0 +1,7 @@
+package com.mirego.interop.kotlin.test.property
+
+import kotlin.js.JsName
+
+class ClassWithByteProperty(byteProperty: Byte) {
+    val byteProperty = byteProperty
+}

--- a/kotlin-interop-test-cases/src/commonMain/kotlin/test/property/ClassWithCharProperty.kt
+++ b/kotlin-interop-test-cases/src/commonMain/kotlin/test/property/ClassWithCharProperty.kt
@@ -1,0 +1,7 @@
+package com.mirego.interop.kotlin.test.property
+
+import kotlin.js.JsName
+
+class ClassWithCharProperty(charProperty: Char) {
+    val charProperty = charProperty
+}

--- a/kotlin-interop-test-cases/src/commonMain/kotlin/test/property/ClassWithCharSequenceProperty.kt
+++ b/kotlin-interop-test-cases/src/commonMain/kotlin/test/property/ClassWithCharSequenceProperty.kt
@@ -1,0 +1,7 @@
+package com.mirego.interop.kotlin.test.property
+
+import kotlin.js.JsName
+
+class ClassWithCharSequenceProperty(charSequenceProperty: CharSequence) {
+    val charSequenceProperty = charSequenceProperty
+}

--- a/kotlin-interop-test-cases/src/commonMain/kotlin/test/property/ClassWithDoubleProperty.kt
+++ b/kotlin-interop-test-cases/src/commonMain/kotlin/test/property/ClassWithDoubleProperty.kt
@@ -1,0 +1,7 @@
+package com.mirego.interop.kotlin.test.property
+
+import kotlin.js.JsName
+
+class ClassWithDoubleProperty(doubleProperty: Double) {
+    val doubleProperty = doubleProperty
+}

--- a/kotlin-interop-test-cases/src/commonMain/kotlin/test/property/ClassWithEscapedStringProperty.kt
+++ b/kotlin-interop-test-cases/src/commonMain/kotlin/test/property/ClassWithEscapedStringProperty.kt
@@ -1,0 +1,7 @@
+package com.mirego.interop.kotlin.test.property
+
+import kotlin.js.JsName
+
+class ClassWithEscapedStringProperty(escapedString: String) {
+    val escapedString = escapedString
+}

--- a/kotlin-interop-test-cases/src/commonMain/kotlin/test/property/ClassWithFloatProperty.kt
+++ b/kotlin-interop-test-cases/src/commonMain/kotlin/test/property/ClassWithFloatProperty.kt
@@ -1,0 +1,7 @@
+package com.mirego.interop.kotlin.test.property
+
+import kotlin.js.JsName
+
+class ClassWithFloatProperty(floatProperty: Float) {
+    val floatProperty = floatProperty
+}

--- a/kotlin-interop-test-cases/src/commonMain/kotlin/test/property/ClassWithIntProperty.kt
+++ b/kotlin-interop-test-cases/src/commonMain/kotlin/test/property/ClassWithIntProperty.kt
@@ -1,0 +1,7 @@
+package com.mirego.interop.kotlin.test.property
+
+import kotlin.js.JsName
+
+class ClassWithIntProperty(intProperty: Int) {
+    val intProperty = intProperty
+}

--- a/kotlin-interop-test-cases/src/commonMain/kotlin/test/property/ClassWithLateInitializedProperty.kt
+++ b/kotlin-interop-test-cases/src/commonMain/kotlin/test/property/ClassWithLateInitializedProperty.kt
@@ -1,0 +1,12 @@
+package com.mirego.interop.kotlin.test.property
+
+import kotlin.js.JsName
+
+class ClassWithLateInitializedProperty() {
+    @Suppress("UNNECESSARY_LATEINIT")
+    lateinit var lateInitializedProperty: String
+
+    init {
+        lateInitializedProperty = "initialized"
+    }
+}

--- a/kotlin-interop-test-cases/src/commonMain/kotlin/test/property/ClassWithLateNonInitializedProperty.kt
+++ b/kotlin-interop-test-cases/src/commonMain/kotlin/test/property/ClassWithLateNonInitializedProperty.kt
@@ -1,0 +1,7 @@
+package com.mirego.interop.kotlin.test.property
+
+import kotlin.js.JsName
+
+class ClassWithLateNonInitializedProperty() {
+    lateinit var lateNonInitializedProperty: String
+}

--- a/kotlin-interop-test-cases/src/commonMain/kotlin/test/property/ClassWithListProperty.kt
+++ b/kotlin-interop-test-cases/src/commonMain/kotlin/test/property/ClassWithListProperty.kt
@@ -1,0 +1,7 @@
+package com.mirego.interop.kotlin.test.property
+
+import kotlin.js.JsName
+
+class ClassWithListProperty(listProperty: List<String>) {
+    val listProperty = listProperty
+}

--- a/kotlin-interop-test-cases/src/commonMain/kotlin/test/property/ClassWithLongProperty.kt
+++ b/kotlin-interop-test-cases/src/commonMain/kotlin/test/property/ClassWithLongProperty.kt
@@ -1,0 +1,7 @@
+package com.mirego.interop.kotlin.test.property
+
+import kotlin.js.JsName
+
+class ClassWithLongProperty(longProperty: Long) {
+    val longProperty = longProperty
+}

--- a/kotlin-interop-test-cases/src/commonMain/kotlin/test/property/ClassWithNullableBooleanProperty.kt
+++ b/kotlin-interop-test-cases/src/commonMain/kotlin/test/property/ClassWithNullableBooleanProperty.kt
@@ -1,0 +1,7 @@
+package com.mirego.interop.kotlin.test.property
+
+import kotlin.js.JsName
+
+class ClassWithNullableBooleanProperty(nullableBoolean: Boolean?) {
+    val nullableBoolean = nullableBoolean
+}

--- a/kotlin-interop-test-cases/src/commonMain/kotlin/test/property/ClassWithNullableProperty.kt
+++ b/kotlin-interop-test-cases/src/commonMain/kotlin/test/property/ClassWithNullableProperty.kt
@@ -1,0 +1,7 @@
+package com.mirego.interop.kotlin.test.property
+
+import kotlin.js.JsName
+
+class ClassWithNullableProperty(nullableProperty: String?) {
+    val nullableProperty = nullableProperty
+}

--- a/kotlin-interop-test-cases/src/commonMain/kotlin/test/property/ClassWithPublicImmutableProperty.kt
+++ b/kotlin-interop-test-cases/src/commonMain/kotlin/test/property/ClassWithPublicImmutableProperty.kt
@@ -1,0 +1,7 @@
+package com.mirego.interop.kotlin.test.property
+
+import kotlin.js.JsName
+
+class ClassWithPublicImmutableProperty(immutableProperty: String) {
+    val immutableProperty = immutableProperty
+}

--- a/kotlin-interop-test-cases/src/commonMain/kotlin/test/property/ClassWithPublicMutableProperty.kt
+++ b/kotlin-interop-test-cases/src/commonMain/kotlin/test/property/ClassWithPublicMutableProperty.kt
@@ -1,0 +1,7 @@
+package com.mirego.interop.kotlin.test.property
+
+import kotlin.js.JsName
+
+class ClassWithPublicMutableProperty(mutableProperty: String) {
+    var mutableProperty = mutableProperty
+}

--- a/kotlin-interop-test-cases/src/commonMain/kotlin/test/property/ClassWithShortProperty.kt
+++ b/kotlin-interop-test-cases/src/commonMain/kotlin/test/property/ClassWithShortProperty.kt
@@ -1,0 +1,7 @@
+package com.mirego.interop.kotlin.test.property
+
+import kotlin.js.JsName
+
+class ClassWithShortProperty(shortProperty: Short) {
+    val shortProperty = shortProperty
+}

--- a/kotlin-interop-test-cases/src/commonMain/kotlin/test/property/ClassWithStringProperty.kt
+++ b/kotlin-interop-test-cases/src/commonMain/kotlin/test/property/ClassWithStringProperty.kt
@@ -1,0 +1,7 @@
+package com.mirego.interop.kotlin.test.property
+
+import kotlin.js.JsName
+
+class ClassWithStringProperty(stringProperty: String) {
+    val stringProperty = stringProperty
+}

--- a/kotlin-native-tests/src/test/java/InterfacesTests.java
+++ b/kotlin-native-tests/src/test/java/InterfacesTests.java
@@ -12,26 +12,26 @@ public class InterfacesTests extends TestCase {
     // @Test
     public void testInterfaceWithInt() {
         WithInt withInt = new WithInt();
-        assert (withInt.main(args) == 1);
+        assertEquals(1, withInt.main(args));
     }
 
     @Test
     public void testInterfaceWithNullableInt() {
         WithNullableInt withNullableInt = new WithNullableInt();
-        assert (withNullableInt.main(args) == Integer.valueOf(1));
+        assertEquals(Integer.valueOf(1), withNullableInt.main(args));
     }
 
     // @Test
     public void testInterfaceWithList() {
         WithList withList = new WithList();
         List list = withList.main(args);
-        assert (list.get(0) == Integer.valueOf(1));
+        assertEquals(Integer.valueOf(1), list.get(0));
     }
 
     @Test
     public void testInterfaceWithGenerics() {
         WithGenerics withGenerics = new WithGenerics();
-        assert (withGenerics.main(args) == Integer.valueOf(5));
+        assertEquals(Integer.valueOf(9), withGenerics.main(args));
     }
 
 }

--- a/kotlin-native-tests/src/test/java/ObjectsTests.java
+++ b/kotlin-native-tests/src/test/java/ObjectsTests.java
@@ -12,13 +12,19 @@ public class ObjectsTests extends TestCase {
     @Test
     public void testStaticMethodWithoutParamsWithAnnotation() {
         StaticMethodWithoutParamWithAnnotation staticWithouParam = new StaticMethodWithoutParamWithAnnotation();
-        assert(staticWithouParam.main(args) == "return");
+        assertEquals("return", staticWithouParam.main(args));
     }
 
     @Test
     public void testStaticMethodWithStringParamsWithAnnotation() {
         StaticMethodWithStringParamWithAnnotation staticWithStringParam = new StaticMethodWithStringParamWithAnnotation();
-        assert(staticWithStringParam.main(args) == "stringAsParam");
+        assertEquals("stringAsParam", staticWithStringParam.main(args));
+    }
+
+    @Test
+    public void testStaticMethodWithGenericParamsWithAnnotation() {
+        StaticMethodWithGenericParamWithAnnotation staticMethodWithGenericParam = new StaticMethodWithGenericParamWithAnnotation();
+        assertEquals("stringGeneric", staticMethodWithGenericParam.main(args));
     }
 
     // todo javautilList vs NSArray

--- a/make/kotlin.mk
+++ b/make/kotlin.mk
@@ -9,6 +9,7 @@ KOTLIN_NATIVE_DIR = $(J2OBJC_ROOT)/kotlin-native-tests
 KOTLIN_NATIVE_BUILD_OUTPUT_DIR = $(KOTLIN_NATIVE_DIR)/build_result
 KOTLIN_NATIVE_SOURCE_DIR = $(KOTLIN_NATIVE_DIR)/src/test/java
 TRANSLATOR_DIR = $(J2OBJC_ROOT)/translator
+KOTLIN_JAVA_TEST_DIR = $(TRANSLATOR_DIR)/src/test/java/com/mirego/interop/java/test
 KOTLIN_NATIVE_HEADER_WRAPPER = $(KOTLIN_NATIVE_DIR)/Common_wrapper.h
 
 # files here are disabled for j2objc jira to fix is noted after
@@ -40,8 +41,7 @@ KOTLIN_NATIVE_J2OBJC_DISABLED_TESTS = \
 	EnumWithPropertyAccessProperty.h \
 	EnumWithPropertyAccessProperty.m
 
-KOTLIN_INTEROP_JAVA_SOURCES_DIR = $(KOTLIN_INTEROP_DIR)/src/commonMain/kotlin/com/mirego/interop/java/test
-KOTLIN_INTEROP_JAVA_SOURCES = $(shell find $(KOTLIN_INTEROP_JAVA_SOURCES_DIR) -name '*.java')
+KOTLIN_JAVA_SOURCES = $(shell find $(KOTLIN_JAVA_TEST_DIR) -name '*.java')
 KOTLIN_INTEROP_J2OBJC_OUTPUT_DIR = $(KOTLIN_NATIVE_BUILD_OUTPUT_DIR)/generated_objc/test_cases
 
 KOTLIN_NATIVE_JAVA_SOURCES = $(shell find $(KOTLIN_NATIVE_SOURCE_DIR) -name '*.java')
@@ -86,7 +86,7 @@ kotlin_translate_tests: kotlin_interop kotlin_translator
 	--header-mapping $(KOTLIN_NATIVE_DIR)/header-mapping.j2objc \
 	--prefixes $(KOTLIN_NATIVE_DIR)/prefixes.properties \
 	-d $(KOTLIN_INTEROP_J2OBJC_OUTPUT_DIR) \
-	$(KOTLIN_INTEROP_JAVA_SOURCES) \
+	$(KOTLIN_JAVA_SOURCES) \
 	$(KOTLIN_NATIVE_JAVA_SOURCES)
 
 KOTLIN_NATIVE_TESTS_J2OBJC_OUTPUT_SOURCES = $(shell find $(KOTLIN_INTEROP_J2OBJC_OUTPUT_DIR) -name '*.m')

--- a/translator/src/main/java/com/google/devtools/j2objc/gen/StatementGenerator.java
+++ b/translator/src/main/java/com/google/devtools/j2objc/gen/StatementGenerator.java
@@ -1052,9 +1052,10 @@ public class StatementGenerator extends UnitTreeVisitor {
 
     int flags = kotlinMetaData.getFlags();
     if (Flag.Class.IS_ENUM_CLASS.invoke(flags)) {
-      if (expression instanceof SimpleName) {
-        SimpleName caseEnumValue = (SimpleName) expression;
-        String caseEnumValueName = caseEnumValue.getIdentifier();
+
+      if (expression instanceof Name) {
+        Name caseEnumValue = (Name) expression;
+        String caseEnumValueName = caseEnumValue.toString();
 
         int ordinalForEnumValue = findOrdinalForEnumValue(kotlinMetaData, caseEnumValueName);
         buffer.append(ordinalForEnumValue + ":");
@@ -1062,7 +1063,7 @@ public class StatementGenerator extends UnitTreeVisitor {
         // add comment so a human reading the code knows what each ordinals match to what enum values
         buffer.append(" // " + caseEnumValueName + "\n");
       } else {
-        throw new RuntimeException("In kotlin switch case only SimpleName enum cases supported: " + expression.getClass());
+        throw new RuntimeException("In kotlin switch case only instanceof Name classes enum cases supported: " + expression.getClass());
       }
     } else {
       expression.accept(this);

--- a/translator/src/test/java/com/google/devtools/j2objc/kotlin/InterfacesTest.java
+++ b/translator/src/test/java/com/google/devtools/j2objc/kotlin/InterfacesTest.java
@@ -55,7 +55,9 @@ public class InterfacesTest extends GenerationTest {
     String className = WithGenerics.class.getSimpleName();
     String translation = translateJavaSourceFileForKotlinTest(className, testPackage, ".m");
 
-    assertTranslation(translation, "return [((JavaLangInteger *) nil_chk([((id<CommonInterfaceWithGenerics>) nil_chk(process)) convertInput:JavaLangInteger_valueOfWithInt_(5)])) intValue];");
+    assertTranslation(translation, "convertInput:JavaLangInteger_valueOfWithInt_(5)])) intValue]");
+    assertTranslation(translation, "[process convertWithFunctionGenericOtherInput:JavaLangInteger_valueOfWithInt_(3)])) intValue]");
+    assertTranslation(translation, "[process convertWithAnotherFunctionGenericAnotherInput:JavaLangInteger_valueOfWithInt_(1)])) intValue]");
   }
 
 }

--- a/translator/src/test/java/com/google/devtools/j2objc/kotlin/ObjectsTest.java
+++ b/translator/src/test/java/com/google/devtools/j2objc/kotlin/ObjectsTest.java
@@ -1,6 +1,7 @@
 package com.google.devtools.j2objc.kotlin;
 
 import com.google.devtools.j2objc.GenerationTest;
+import com.mirego.interop.java.test.objects.StaticMethodWithGenericParamWithAnnotation;
 import com.mirego.interop.java.test.objects.StaticMethodWithListParamWithAnnotation;
 import com.mirego.interop.java.test.objects.StaticMethodWithStringParamWithAnnotation;
 import com.mirego.interop.java.test.objects.StaticMethodWithoutParamWithAnnotation;
@@ -27,6 +28,15 @@ public class ObjectsTest extends GenerationTest {
     String translation = translateJavaSourceFileForKotlinTest(className, testPackage, ".m");
 
     assertTranslation(translation, "NSString *returnValue = [[CommonObjectWithMethod objectWithMethod] staticMethodWithStringParamWithAnnotationInput:@\"stringAsParam\"];");
+  }
+
+  @Test
+  public void testStaticMethodWitGenericParamsWithAnnotation() throws IOException {
+
+    String className = StaticMethodWithGenericParamWithAnnotation.class.getSimpleName();
+    String translation = translateJavaSourceFileForKotlinTest(className, testPackage, ".m");
+
+    assertTranslation(translation, "return [[CommonObjectWithMethod objectWithMethod] staticMethodWithGenericParamInput:testString];");
   }
 
   // todo javautillist vs  NSarray

--- a/translator/src/test/java/com/mirego/interop/java/test
+++ b/translator/src/test/java/com/mirego/interop/java/test
@@ -1,1 +1,0 @@
-../../../../../../../../submodules/kotlin-interop-test-cases/kotlin/com/mirego/interop/java/test

--- a/translator/src/test/java/com/mirego/interop/java/test/constructor/DefaultConstructor.java
+++ b/translator/src/test/java/com/mirego/interop/java/test/constructor/DefaultConstructor.java
@@ -1,0 +1,13 @@
+package com.mirego.interop.java.test.constructor;
+
+import com.mirego.interop.kotlin.test.constructor.ClassWithDefaultConstructor;
+
+public class DefaultConstructor {
+
+    public static ClassWithDefaultConstructor main(String[] args) {
+
+        ClassWithDefaultConstructor defaultConstructor = new ClassWithDefaultConstructor("ClassWithDefaultConstructor");
+
+        return defaultConstructor;
+    }
+}

--- a/translator/src/test/java/com/mirego/interop/java/test/constructor/DefaultConstructorMultipleParameters.java
+++ b/translator/src/test/java/com/mirego/interop/java/test/constructor/DefaultConstructorMultipleParameters.java
@@ -1,0 +1,13 @@
+package com.mirego.interop.java.test.constructor;
+
+import com.mirego.interop.kotlin.test.constructor.ClassWithDefaultConstructorMultipleParameters;
+
+public class DefaultConstructorMultipleParameters {
+
+    public static ClassWithDefaultConstructorMultipleParameters main(String[] args) {
+
+        ClassWithDefaultConstructorMultipleParameters defaultConstructorMultipleParameters = new ClassWithDefaultConstructorMultipleParameters("First", "Second");
+
+        return defaultConstructorMultipleParameters;
+    }
+}

--- a/translator/src/test/java/com/mirego/interop/java/test/constructor/DefaultConstructorWithDefaultValue.java
+++ b/translator/src/test/java/com/mirego/interop/java/test/constructor/DefaultConstructorWithDefaultValue.java
@@ -1,0 +1,13 @@
+package com.mirego.interop.java.test.constructor;
+
+import com.mirego.interop.kotlin.test.constructor.ClassWithDefaultConstructorWithDefaultValue;
+
+public class DefaultConstructorWithDefaultValue {
+
+    public static ClassWithDefaultConstructorWithDefaultValue main(String[] args) {
+
+        ClassWithDefaultConstructorWithDefaultValue defaultConstructorWithDefaultValue = new ClassWithDefaultConstructorWithDefaultValue();
+
+        return defaultConstructorWithDefaultValue;
+    }
+}

--- a/translator/src/test/java/com/mirego/interop/java/test/constructor/DefaultConstructorWithInitBlock.java
+++ b/translator/src/test/java/com/mirego/interop/java/test/constructor/DefaultConstructorWithInitBlock.java
@@ -1,0 +1,13 @@
+package com.mirego.interop.java.test.constructor;
+
+import com.mirego.interop.kotlin.test.constructor.ClassWithDefaultConstructorWithInitBlock;
+
+public class DefaultConstructorWithInitBlock {
+
+    public static ClassWithDefaultConstructorWithInitBlock main(String[] args) {
+
+        ClassWithDefaultConstructorWithInitBlock defaultConstructorWithInitBlock = new ClassWithDefaultConstructorWithInitBlock("ClassWithDefaultConstructorWithInitBlock");
+
+        return defaultConstructorWithInitBlock;
+    }
+}

--- a/translator/src/test/java/com/mirego/interop/java/test/constructor/DefaultConstructorWithIntParameter.java
+++ b/translator/src/test/java/com/mirego/interop/java/test/constructor/DefaultConstructorWithIntParameter.java
@@ -1,0 +1,13 @@
+package com.mirego.interop.java.test.constructor;
+
+import com.mirego.interop.kotlin.test.constructor.ClassWithDefaultConstructorWithIntParameter;
+
+public class DefaultConstructorWithIntParameter {
+
+    public static ClassWithDefaultConstructorWithIntParameter main(String[] args) {
+
+        ClassWithDefaultConstructorWithIntParameter defaultConstructorWithIntParameter = new ClassWithDefaultConstructorWithIntParameter(1);
+
+        return defaultConstructorWithIntParameter;
+    }
+}

--- a/translator/src/test/java/com/mirego/interop/java/test/constructor/DefaultConstructorWithListParameter.java
+++ b/translator/src/test/java/com/mirego/interop/java/test/constructor/DefaultConstructorWithListParameter.java
@@ -1,0 +1,15 @@
+package com.mirego.interop.java.test.constructor;
+
+import com.mirego.interop.kotlin.test.constructor.ClassWithDefaultConstructorWithListParameter;
+import java.util.Arrays;
+
+public class DefaultConstructorWithListParameter {
+
+    public static ClassWithDefaultConstructorWithListParameter main(String[] args) {
+
+        ClassWithDefaultConstructorWithListParameter defaultConstructorWithListParameter =
+            new ClassWithDefaultConstructorWithListParameter(Arrays.asList(1));
+
+        return defaultConstructorWithListParameter;
+    }
+}

--- a/translator/src/test/java/com/mirego/interop/java/test/constructor/DefaultConstructorWithMultipleInitBlocks.java
+++ b/translator/src/test/java/com/mirego/interop/java/test/constructor/DefaultConstructorWithMultipleInitBlocks.java
@@ -1,0 +1,13 @@
+package com.mirego.interop.java.test.constructor;
+
+import com.mirego.interop.kotlin.test.constructor.ClassWithDefaultConstructorWithMultipleInitBlocks;
+
+public class DefaultConstructorWithMultipleInitBlocks {
+
+    public static ClassWithDefaultConstructorWithMultipleInitBlocks main(String[] args) {
+
+        ClassWithDefaultConstructorWithMultipleInitBlocks defaultConstructorWithMultipleInitBlocks = new ClassWithDefaultConstructorWithMultipleInitBlocks("ClassWithDefaultConstructorWithMultipleInitBlocks");
+
+        return defaultConstructorWithMultipleInitBlocks;
+    }
+}

--- a/translator/src/test/java/com/mirego/interop/java/test/constructor/DefaultConstructorWithMutableListParameter.java
+++ b/translator/src/test/java/com/mirego/interop/java/test/constructor/DefaultConstructorWithMutableListParameter.java
@@ -1,0 +1,16 @@
+package com.mirego.interop.java.test.constructor;
+
+import com.mirego.interop.kotlin.test.constructor.ClassWithDefaultConstructorWithMutableListParameter;
+import java.util.Arrays;
+import java.util.List;
+
+public class DefaultConstructorWithMutableListParameter {
+
+    public static ClassWithDefaultConstructorWithMutableListParameter main(String[] args) {
+
+        ClassWithDefaultConstructorWithMutableListParameter defaultConstructorWithMutableListParameter =
+            new ClassWithDefaultConstructorWithMutableListParameter(Arrays.asList(1));
+
+        return defaultConstructorWithMutableListParameter;
+    }
+}

--- a/translator/src/test/java/com/mirego/interop/java/test/constructor/DefaultConstructorWithNullableIntParameter.java
+++ b/translator/src/test/java/com/mirego/interop/java/test/constructor/DefaultConstructorWithNullableIntParameter.java
@@ -1,0 +1,15 @@
+package com.mirego.interop.java.test.constructor;
+
+import com.mirego.interop.kotlin.test.constructor.ClassWithDefaultConstructorWithNullableIntParameter;
+
+public class DefaultConstructorWithNullableIntParameter {
+
+    public static ClassWithDefaultConstructorWithNullableIntParameter main(String[] args) {
+
+        Integer nullableInteger = 1;
+        ClassWithDefaultConstructorWithNullableIntParameter defaultConstructorWithNullableIntParameter =
+            new ClassWithDefaultConstructorWithNullableIntParameter(nullableInteger);
+
+        return defaultConstructorWithNullableIntParameter;
+    }
+}

--- a/translator/src/test/java/com/mirego/interop/java/test/constructor/DefaultConstructorWithPrivateProperty.java
+++ b/translator/src/test/java/com/mirego/interop/java/test/constructor/DefaultConstructorWithPrivateProperty.java
@@ -1,0 +1,13 @@
+package com.mirego.interop.java.test.constructor;
+
+import com.mirego.interop.kotlin.test.constructor.ClassWithDefaultConstructorWithPrivateProperty;
+
+public class DefaultConstructorWithPrivateProperty {
+
+    public static ClassWithDefaultConstructorWithPrivateProperty main(String[] args) {
+
+        ClassWithDefaultConstructorWithPrivateProperty defaultConstructorWithPrivateProperty = new ClassWithDefaultConstructorWithPrivateProperty("ClassWithDefaultConstructorWithPrivateProperty");
+
+        return defaultConstructorWithPrivateProperty;
+    }
+}

--- a/translator/src/test/java/com/mirego/interop/java/test/constructor/DefaultConstructorWithUserClassParameter.java
+++ b/translator/src/test/java/com/mirego/interop/java/test/constructor/DefaultConstructorWithUserClassParameter.java
@@ -1,0 +1,14 @@
+package com.mirego.interop.java.test.constructor;
+
+import com.mirego.interop.kotlin.test.constructor.ClassWithDefaultConstructorWithUserClassParameter;
+import com.mirego.interop.kotlin.test.constructor.ClassWithoutConstructor;
+
+public class DefaultConstructorWithUserClassParameter {
+
+    public static ClassWithDefaultConstructorWithUserClassParameter main(String[] args) {
+
+        ClassWithDefaultConstructorWithUserClassParameter defaultConstructorWithUserClassParameter = new ClassWithDefaultConstructorWithUserClassParameter(new ClassWithoutConstructor());
+
+        return defaultConstructorWithUserClassParameter;
+    }
+}

--- a/translator/src/test/java/com/mirego/interop/java/test/constructor/KotlinClassVariable.java
+++ b/translator/src/test/java/com/mirego/interop/java/test/constructor/KotlinClassVariable.java
@@ -1,0 +1,10 @@
+package com.mirego.interop.java.test.constructor;
+
+import com.mirego.interop.kotlin.test.constructor.ClassWithDefaultConstructor;
+
+public class KotlinClassVariable {
+
+    public static String main(String[] args) {
+        return ClassWithDefaultConstructor.class.getName();
+    }
+}

--- a/translator/src/test/java/com/mirego/interop/java/test/constructor/SecondaryConstructor.java
+++ b/translator/src/test/java/com/mirego/interop/java/test/constructor/SecondaryConstructor.java
@@ -1,0 +1,13 @@
+package com.mirego.interop.java.test.constructor;
+
+import com.mirego.interop.kotlin.test.constructor.ClassWithSecondaryConstructor;
+
+public class SecondaryConstructor {
+
+    public static ClassWithSecondaryConstructor main(String[] args) {
+
+        ClassWithSecondaryConstructor secondaryConstructor = new ClassWithSecondaryConstructor();
+
+        return secondaryConstructor;
+    }
+}

--- a/translator/src/test/java/com/mirego/interop/java/test/constructor/WithoutConstructor.java
+++ b/translator/src/test/java/com/mirego/interop/java/test/constructor/WithoutConstructor.java
@@ -1,0 +1,13 @@
+package com.mirego.interop.java.test.constructor;
+
+import com.mirego.interop.kotlin.test.constructor.ClassWithoutConstructor;
+
+public class WithoutConstructor {
+
+    public static ClassWithoutConstructor main(String[] args) {
+
+        ClassWithoutConstructor withoutConstructor = new ClassWithoutConstructor();
+
+        return withoutConstructor;
+    }
+}

--- a/translator/src/test/java/com/mirego/interop/java/test/dataclass/MutableDataClassSetter.java
+++ b/translator/src/test/java/com/mirego/interop/java/test/dataclass/MutableDataClassSetter.java
@@ -1,0 +1,12 @@
+package com.mirego.interop.java.test.dataclass;
+
+import com.mirego.interop.kotlin.test.dataclass.MutableDataClass;
+
+public class MutableDataClassSetter {
+
+    public static String main(String[] args) {
+        MutableDataClass mutableDataClass = new MutableDataClass("dataClassName", 1);
+        mutableDataClass.setName("dataClassName-updated");
+        return mutableDataClass.getName();
+    }
+}

--- a/translator/src/test/java/com/mirego/interop/java/test/dataclass/SimpleDataClassComponentGetter.java
+++ b/translator/src/test/java/com/mirego/interop/java/test/dataclass/SimpleDataClassComponentGetter.java
@@ -1,0 +1,11 @@
+package com.mirego.interop.java.test.dataclass;
+
+import com.mirego.interop.kotlin.test.dataclass.SimpleDataClass;
+
+public class SimpleDataClassComponentGetter {
+
+    public static String main(String[] args) {
+        SimpleDataClass simpleDataClass = new SimpleDataClass("dataClassName", 1);
+        return simpleDataClass.component1();
+    }
+}

--- a/translator/src/test/java/com/mirego/interop/java/test/dataclass/SimpleDataClassConstructor.java
+++ b/translator/src/test/java/com/mirego/interop/java/test/dataclass/SimpleDataClassConstructor.java
@@ -1,0 +1,11 @@
+package com.mirego.interop.java.test.dataclass;
+
+import com.mirego.interop.kotlin.test.dataclass.SimpleDataClass;
+
+public class SimpleDataClassConstructor {
+
+    public static SimpleDataClass main(String[] args) {
+        SimpleDataClass simpleDataClass = new SimpleDataClass("dataClassName", 1);
+        return simpleDataClass;
+    }
+}

--- a/translator/src/test/java/com/mirego/interop/java/test/dataclass/SimpleDataClassCopy.java
+++ b/translator/src/test/java/com/mirego/interop/java/test/dataclass/SimpleDataClassCopy.java
@@ -1,0 +1,12 @@
+package com.mirego.interop.java.test.dataclass;
+
+import com.mirego.interop.kotlin.test.dataclass.SimpleDataClass;
+
+public class SimpleDataClassCopy {
+
+    public static boolean main(String[] args) {
+        SimpleDataClass simpleDataClass = new SimpleDataClass("dataClassName", 1);
+        SimpleDataClass simpleDataClass2 = simpleDataClass.copy("dataClassName", 1);
+        return simpleDataClass.equals(simpleDataClass2);
+    }
+}

--- a/translator/src/test/java/com/mirego/interop/java/test/dataclass/SimpleDataClassEquals.java
+++ b/translator/src/test/java/com/mirego/interop/java/test/dataclass/SimpleDataClassEquals.java
@@ -1,0 +1,12 @@
+package com.mirego.interop.java.test.dataclass;
+
+import com.mirego.interop.kotlin.test.dataclass.SimpleDataClass;
+
+public class SimpleDataClassEquals {
+
+    public static boolean main(String[] args) {
+        SimpleDataClass simpleDataClass = new SimpleDataClass("dataClassName", 1);
+        SimpleDataClass simpleDataClass2 = new SimpleDataClass("dataClassName", 1);
+        return simpleDataClass.equals(simpleDataClass2);
+    }
+}

--- a/translator/src/test/java/com/mirego/interop/java/test/dataclass/SimpleDataClassGetter.java
+++ b/translator/src/test/java/com/mirego/interop/java/test/dataclass/SimpleDataClassGetter.java
@@ -1,0 +1,11 @@
+package com.mirego.interop.java.test.dataclass;
+
+import com.mirego.interop.kotlin.test.dataclass.SimpleDataClass;
+
+public class SimpleDataClassGetter {
+
+    public static String main(String[] args) {
+        SimpleDataClass simpleDataClass = new SimpleDataClass("dataClassName", 1);
+        return simpleDataClass.getName();
+    }
+}

--- a/translator/src/test/java/com/mirego/interop/java/test/enums/EnumWithPropertyAccessProperty.java
+++ b/translator/src/test/java/com/mirego/interop/java/test/enums/EnumWithPropertyAccessProperty.java
@@ -1,0 +1,11 @@
+package com.mirego.interop.java.test.enums;
+
+import com.mirego.interop.kotlin.test.enums.EnumWithProperty;
+
+public class EnumWithPropertyAccessProperty {
+
+    public static String main(String[] args) {
+        EnumWithProperty enumWithProperty = EnumWithProperty.ENUMVALUE1;
+        return enumWithProperty.getContent();
+    }
+}

--- a/translator/src/test/java/com/mirego/interop/java/test/enums/SimpleEnumAccessValue1.java
+++ b/translator/src/test/java/com/mirego/interop/java/test/enums/SimpleEnumAccessValue1.java
@@ -1,0 +1,10 @@
+package com.mirego.interop.java.test.enums;
+
+import com.mirego.interop.kotlin.test.enums.SimpleEnum;
+
+public class SimpleEnumAccessValue1 {
+
+    public static String main(String[] args) {
+        return SimpleEnum.ENUMVALUE1.toString();
+    }
+}

--- a/translator/src/test/java/com/mirego/interop/java/test/enums/SimpleEnumAccessValue2.java
+++ b/translator/src/test/java/com/mirego/interop/java/test/enums/SimpleEnumAccessValue2.java
@@ -1,0 +1,10 @@
+package com.mirego.interop.java.test.enums;
+
+import com.mirego.interop.kotlin.test.enums.SimpleEnum;
+
+public class SimpleEnumAccessValue2 {
+
+    public static String main(String[] args) {
+        return SimpleEnum.ENUM_VALUE2.toString();
+    }
+}

--- a/translator/src/test/java/com/mirego/interop/java/test/enums/SimpleEnumAccessValue3.java
+++ b/translator/src/test/java/com/mirego/interop/java/test/enums/SimpleEnumAccessValue3.java
@@ -1,0 +1,10 @@
+package com.mirego.interop.java.test.enums;
+
+import com.mirego.interop.kotlin.test.enums.SimpleEnum;
+
+public class SimpleEnumAccessValue3 {
+
+    public static String main(String[] args) {
+        return SimpleEnum.ENUM_VALUE_3.toString();
+    }
+}

--- a/translator/src/test/java/com/mirego/interop/java/test/enums/SimpleEnumOrdinal.java
+++ b/translator/src/test/java/com/mirego/interop/java/test/enums/SimpleEnumOrdinal.java
@@ -1,0 +1,10 @@
+package com.mirego.interop.java.test.enums;
+
+import com.mirego.interop.kotlin.test.enums.SimpleEnum;
+
+public class SimpleEnumOrdinal {
+
+    public static int main(String[] args) {
+        return SimpleEnum.ENUMVALUE1.ordinal();
+    }
+}

--- a/translator/src/test/java/com/mirego/interop/java/test/enums/SimpleEnumSwitchCase.java
+++ b/translator/src/test/java/com/mirego/interop/java/test/enums/SimpleEnumSwitchCase.java
@@ -1,0 +1,26 @@
+package com.mirego.interop.java.test.enums;
+
+import com.mirego.interop.kotlin.test.enums.SimpleEnum;
+
+import static com.mirego.interop.kotlin.test.enums.SimpleEnum.*;
+
+public class SimpleEnumSwitchCase {
+
+    public static int main(String[] args) {
+        SimpleEnum testEnum = ENUMVALUE1;
+        switch(testEnum)
+        {
+            case ENUMVALUE1:
+                return 1;
+
+            case ENUM_VALUE2:
+                return 2;
+
+            case ENUM_VALUE_3:
+                return 3;
+
+            default:
+                return 4;
+        }
+    }
+}

--- a/translator/src/test/java/com/mirego/interop/java/test/enums/SimpleEnumValues.java
+++ b/translator/src/test/java/com/mirego/interop/java/test/enums/SimpleEnumValues.java
@@ -1,0 +1,14 @@
+package com.mirego.interop.java.test.enums;
+
+import com.mirego.interop.kotlin.test.enums.SimpleEnum;
+
+public class SimpleEnumValues {
+
+    public static String main(String[] args) {
+        String combinedEnumNames = "";
+        for (SimpleEnum value : SimpleEnum.values()) {
+            combinedEnumNames += value.name();
+        }
+        return combinedEnumNames;
+    }
+}

--- a/translator/src/test/java/com/mirego/interop/java/test/function/PublicExtensionFunction.java
+++ b/translator/src/test/java/com/mirego/interop/java/test/function/PublicExtensionFunction.java
@@ -1,0 +1,13 @@
+package com.mirego.interop.java.test.function;
+
+import com.mirego.interop.kotlin.test.function.ClassWithPublicFunctions;
+
+public class PublicExtensionFunction {
+
+    public static String main(String[] args) {
+
+        ClassWithPublicFunctions classWithPublicFunctions = new ClassWithPublicFunctions();
+
+        return classWithPublicFunctions.extensionFunction("extension");
+    }
+}

--- a/translator/src/test/java/com/mirego/interop/java/test/function/PublicFunctionReturningBoolean.java
+++ b/translator/src/test/java/com/mirego/interop/java/test/function/PublicFunctionReturningBoolean.java
@@ -1,0 +1,13 @@
+package com.mirego.interop.java.test.function;
+
+import com.mirego.interop.kotlin.test.function.ClassWithPublicFunctions;
+
+public class PublicFunctionReturningBoolean {
+
+    public static Boolean main(String[] args) {
+
+        ClassWithPublicFunctions classWithPublicFunctions = new ClassWithPublicFunctions();
+
+        return classWithPublicFunctions.returnBoolean();
+    }
+}

--- a/translator/src/test/java/com/mirego/interop/java/test/function/PublicFunctionReturningCharacter.java
+++ b/translator/src/test/java/com/mirego/interop/java/test/function/PublicFunctionReturningCharacter.java
@@ -1,0 +1,13 @@
+package com.mirego.interop.java.test.function;
+
+import com.mirego.interop.kotlin.test.function.ClassWithPublicFunctions;
+
+public class PublicFunctionReturningCharacter {
+
+    public static Character main(String[] args) {
+
+        ClassWithPublicFunctions classWithPublicFunctions = new ClassWithPublicFunctions();
+
+        return classWithPublicFunctions.returnCharacter();
+    }
+}

--- a/translator/src/test/java/com/mirego/interop/java/test/function/PublicFunctionReturningDouble.java
+++ b/translator/src/test/java/com/mirego/interop/java/test/function/PublicFunctionReturningDouble.java
@@ -1,0 +1,13 @@
+package com.mirego.interop.java.test.function;
+
+import com.mirego.interop.kotlin.test.function.ClassWithPublicFunctions;
+
+public class PublicFunctionReturningDouble {
+
+    public static Double main(String[] args) {
+
+        ClassWithPublicFunctions classWithPublicFunctions = new ClassWithPublicFunctions();
+
+        return classWithPublicFunctions.returnDouble();
+    }
+}

--- a/translator/src/test/java/com/mirego/interop/java/test/function/PublicFunctionReturningFloat.java
+++ b/translator/src/test/java/com/mirego/interop/java/test/function/PublicFunctionReturningFloat.java
@@ -1,0 +1,13 @@
+package com.mirego.interop.java.test.function;
+
+import com.mirego.interop.kotlin.test.function.ClassWithPublicFunctions;
+
+public class PublicFunctionReturningFloat {
+
+    public static Float main(String[] args) {
+
+        ClassWithPublicFunctions classWithPublicFunctions = new ClassWithPublicFunctions();
+
+        return classWithPublicFunctions.returnFloat();
+    }
+}

--- a/translator/src/test/java/com/mirego/interop/java/test/function/PublicFunctionReturningInteger.java
+++ b/translator/src/test/java/com/mirego/interop/java/test/function/PublicFunctionReturningInteger.java
@@ -1,0 +1,13 @@
+package com.mirego.interop.java.test.function;
+
+import com.mirego.interop.kotlin.test.function.ClassWithPublicFunctions;
+
+public class PublicFunctionReturningInteger {
+
+    public static Integer main(String[] args) {
+
+        ClassWithPublicFunctions classWithPublicFunctions = new ClassWithPublicFunctions();
+
+        return classWithPublicFunctions.returnInt();
+    }
+}

--- a/translator/src/test/java/com/mirego/interop/java/test/function/PublicFunctionReturningLong.java
+++ b/translator/src/test/java/com/mirego/interop/java/test/function/PublicFunctionReturningLong.java
@@ -1,0 +1,13 @@
+package com.mirego.interop.java.test.function;
+
+import com.mirego.interop.kotlin.test.function.ClassWithPublicFunctions;
+
+public class PublicFunctionReturningLong {
+
+    public static Long main(String[] args) {
+
+        ClassWithPublicFunctions classWithPublicFunctions = new ClassWithPublicFunctions();
+
+        return classWithPublicFunctions.returnLong();
+    }
+}

--- a/translator/src/test/java/com/mirego/interop/java/test/function/PublicFunctionReturningPrimitive.java
+++ b/translator/src/test/java/com/mirego/interop/java/test/function/PublicFunctionReturningPrimitive.java
@@ -1,0 +1,13 @@
+package com.mirego.interop.java.test.function;
+
+import com.mirego.interop.kotlin.test.function.ClassWithPublicFunctions;
+
+public class PublicFunctionReturningPrimitive {
+
+    public static int main(String[] args) {
+
+        ClassWithPublicFunctions classWithPublicFunctions = new ClassWithPublicFunctions();
+
+        return classWithPublicFunctions.returnInt();
+    }
+}

--- a/translator/src/test/java/com/mirego/interop/java/test/function/PublicFunctionReturningShort.java
+++ b/translator/src/test/java/com/mirego/interop/java/test/function/PublicFunctionReturningShort.java
@@ -1,0 +1,13 @@
+package com.mirego.interop.java.test.function;
+
+import com.mirego.interop.kotlin.test.function.ClassWithPublicFunctions;
+
+public class PublicFunctionReturningShort {
+
+    public static Short main(String[] args) {
+
+        ClassWithPublicFunctions classWithPublicFunctions = new ClassWithPublicFunctions();
+
+        return classWithPublicFunctions.returnShort();
+    }
+}

--- a/translator/src/test/java/com/mirego/interop/java/test/function/PublicFunctionReturningString.java
+++ b/translator/src/test/java/com/mirego/interop/java/test/function/PublicFunctionReturningString.java
@@ -1,0 +1,13 @@
+package com.mirego.interop.java.test.function;
+
+import com.mirego.interop.kotlin.test.function.ClassWithPublicFunctions;
+
+public class PublicFunctionReturningString {
+
+    public static String main(String[] args) {
+
+        ClassWithPublicFunctions classWithPublicFunctions = new ClassWithPublicFunctions();
+
+        return classWithPublicFunctions.returnString();
+    }
+}

--- a/translator/src/test/java/com/mirego/interop/java/test/function/PublicFunctionReturningUnit.java
+++ b/translator/src/test/java/com/mirego/interop/java/test/function/PublicFunctionReturningUnit.java
@@ -1,0 +1,14 @@
+package com.mirego.interop.java.test.function;
+
+import com.mirego.interop.kotlin.test.function.ClassWithPublicFunctionReturningUnit;
+
+public class PublicFunctionReturningUnit {
+
+    public static ClassWithPublicFunctionReturningUnit main(String[] args) {
+
+        ClassWithPublicFunctionReturningUnit classWithPublicFunctionReturningUnit = new ClassWithPublicFunctionReturningUnit();
+
+        classWithPublicFunctionReturningUnit.returnUnit();
+        return classWithPublicFunctionReturningUnit;
+    }
+}

--- a/translator/src/test/java/com/mirego/interop/java/test/function/PublicFunctionWithDefaultArguments.java
+++ b/translator/src/test/java/com/mirego/interop/java/test/function/PublicFunctionWithDefaultArguments.java
@@ -1,0 +1,13 @@
+package com.mirego.interop.java.test.function;
+
+import com.mirego.interop.kotlin.test.function.ClassWithPublicFunctions;
+
+public class PublicFunctionWithDefaultArguments {
+
+    public static String main(String[] args) {
+
+        ClassWithPublicFunctions classWithPublicFunctions = new ClassWithPublicFunctions();
+
+        return classWithPublicFunctions.withDefaultArguments("default");
+    }
+}

--- a/translator/src/test/java/com/mirego/interop/java/test/function/PublicInnerClassFunction.java
+++ b/translator/src/test/java/com/mirego/interop/java/test/function/PublicInnerClassFunction.java
@@ -1,0 +1,13 @@
+package com.mirego.interop.java.test.function;
+
+import com.mirego.interop.kotlin.test.function.ClassWithPublicFunctions;
+
+public class PublicInnerClassFunction {
+
+    public static Integer main(String[] args) {
+
+        ClassWithPublicFunctions classWithPublicFunctions = new ClassWithPublicFunctions();
+
+        return classWithPublicFunctions.innerClassFunction(1, 2);
+    }
+}

--- a/translator/src/test/java/com/mirego/interop/java/test/function/PublicLambdaFunction.java
+++ b/translator/src/test/java/com/mirego/interop/java/test/function/PublicLambdaFunction.java
@@ -1,0 +1,16 @@
+package com.mirego.interop.java.test.function;
+
+import com.mirego.interop.kotlin.test.function.ClassWithPublicFunctions;
+
+import kotlin.jvm.functions.Function1;
+
+public class PublicLambdaFunction {
+
+    public static Integer main(String[] args) {
+        ClassWithPublicFunctions classWithPublicFunctions = new ClassWithPublicFunctions();
+
+        Function1<Integer, Integer> lambdaFunction = classWithPublicFunctions.getLambdaFunction();
+
+        return lambdaFunction.invoke(3);
+    }
+}

--- a/translator/src/test/java/com/mirego/interop/java/test/function/PublicLocalFunction.java
+++ b/translator/src/test/java/com/mirego/interop/java/test/function/PublicLocalFunction.java
@@ -1,0 +1,13 @@
+package com.mirego.interop.java.test.function;
+
+import com.mirego.interop.kotlin.test.function.ClassWithPublicFunctions;
+
+public class PublicLocalFunction {
+
+    public static String main(String[] args) {
+
+        ClassWithPublicFunctions classWithPublicFunctions = new ClassWithPublicFunctions();
+
+        return classWithPublicFunctions.localFunction();
+    }
+}

--- a/translator/src/test/java/com/mirego/interop/java/test/function/PublicOverloadedFunction.java
+++ b/translator/src/test/java/com/mirego/interop/java/test/function/PublicOverloadedFunction.java
@@ -1,0 +1,13 @@
+package com.mirego.interop.java.test.function;
+
+import com.mirego.interop.kotlin.test.function.ClassWithPublicFunctions;
+
+public class PublicOverloadedFunction {
+
+    public static String main(String[] args) {
+
+        ClassWithPublicFunctions classWithPublicFunctions = new ClassWithPublicFunctions();
+
+        return classWithPublicFunctions.overloadedFunction(1);
+    }
+}

--- a/translator/src/test/java/com/mirego/interop/java/test/function/PublicRecursiveFunction.java
+++ b/translator/src/test/java/com/mirego/interop/java/test/function/PublicRecursiveFunction.java
@@ -1,0 +1,13 @@
+package com.mirego.interop.java.test.function;
+
+import com.mirego.interop.kotlin.test.function.ClassWithPublicFunctions;
+
+public class PublicRecursiveFunction {
+
+    public static Long main(String[] args) {
+
+        ClassWithPublicFunctions classWithPublicFunctions = new ClassWithPublicFunctions();
+
+        return classWithPublicFunctions.recursiveFunction(4);
+    }
+}

--- a/translator/src/test/java/com/mirego/interop/java/test/function/PublicSingleExpressionFunction.java
+++ b/translator/src/test/java/com/mirego/interop/java/test/function/PublicSingleExpressionFunction.java
@@ -1,0 +1,13 @@
+package com.mirego.interop.java.test.function;
+
+import com.mirego.interop.kotlin.test.function.ClassWithPublicFunctions;
+
+public class PublicSingleExpressionFunction {
+
+    public static String main(String[] args) {
+
+        ClassWithPublicFunctions classWithPublicFunctions = new ClassWithPublicFunctions();
+
+        return classWithPublicFunctions.singleExpression();
+    }
+}

--- a/translator/src/test/java/com/mirego/interop/java/test/function/PublicStaticFunction.java
+++ b/translator/src/test/java/com/mirego/interop/java/test/function/PublicStaticFunction.java
@@ -1,0 +1,11 @@
+package com.mirego.interop.java.test.function;
+
+import com.mirego.interop.kotlin.test.function.ClassWithPublicFunctions;
+
+public class PublicStaticFunction {
+
+    public static String main(String[] args) {
+
+        return ClassWithPublicFunctions.Companion.staticReturnString();
+    }
+}

--- a/translator/src/test/java/com/mirego/interop/java/test/function/PublicTailRecursiveFunction.java
+++ b/translator/src/test/java/com/mirego/interop/java/test/function/PublicTailRecursiveFunction.java
@@ -1,0 +1,13 @@
+package com.mirego.interop.java.test.function;
+
+import com.mirego.interop.kotlin.test.function.ClassWithPublicFunctions;
+
+public class PublicTailRecursiveFunction {
+
+    public static Long main(String[] args) {
+
+        ClassWithPublicFunctions classWithPublicFunctions = new ClassWithPublicFunctions();
+
+        return classWithPublicFunctions.tailRecursiveFunction(4, 1);
+    }
+}

--- a/translator/src/test/java/com/mirego/interop/java/test/function/PublicVariableArgumentsFunction.java
+++ b/translator/src/test/java/com/mirego/interop/java/test/function/PublicVariableArgumentsFunction.java
@@ -1,0 +1,13 @@
+package com.mirego.interop.java.test.function;
+
+import com.mirego.interop.kotlin.test.function.ClassWithPublicFunctions;
+
+public class PublicVariableArgumentsFunction {
+
+    public static Integer main(String[] args) {
+
+        ClassWithPublicFunctions classWithPublicFunctions = new ClassWithPublicFunctions();
+
+        return classWithPublicFunctions.variableArgumentsSum(1, 2, 3, 4);
+    }
+}

--- a/translator/src/test/java/com/mirego/interop/java/test/interfaces/WithGenerics.java
+++ b/translator/src/test/java/com/mirego/interop/java/test/interfaces/WithGenerics.java
@@ -14,10 +14,20 @@ public class WithGenerics {
         public U convert(T input) {
             return (U)input;
         }
+
+        @Override
+        public <V> V convertWithFunctionGeneric(V v) {
+            return v;
+        }
+
+        @Override
+        public <W> W convertWithAnotherFunctionGeneric(W w) {
+            return w;
+        }
     }
 
-    public static int main(String[] args) {
+    public static Integer main(String[] args) {
         InterfaceWithGenerics<Integer, Integer> process = process();
-        return process.convert(5);
+        return process.convert(5) + process.convertWithFunctionGeneric(3) + process.convertWithAnotherFunctionGeneric(1);
     }
 }

--- a/translator/src/test/java/com/mirego/interop/java/test/interfaces/WithGenerics.java
+++ b/translator/src/test/java/com/mirego/interop/java/test/interfaces/WithGenerics.java
@@ -1,0 +1,23 @@
+package com.mirego.interop.java.test.interfaces;
+
+import com.mirego.interop.kotlin.test.interfaces.InterfaceWithGenerics;
+
+public class WithGenerics {
+
+    public static <T, U> InterfaceWithGenerics<T, U> process() {
+        return new InterfaceWithGenericsImpl<>();
+    }
+
+    public static class InterfaceWithGenericsImpl<T, U> implements InterfaceWithGenerics<T, U> {
+
+        @Override
+        public U convert(T input) {
+            return (U)input;
+        }
+    }
+
+    public static int main(String[] args) {
+        InterfaceWithGenerics<Integer, Integer> process = process();
+        return process.convert(5);
+    }
+}

--- a/translator/src/test/java/com/mirego/interop/java/test/interfaces/WithInt.java
+++ b/translator/src/test/java/com/mirego/interop/java/test/interfaces/WithInt.java
@@ -1,0 +1,18 @@
+package com.mirego.interop.java.test.interfaces;
+
+import com.mirego.interop.kotlin.test.interfaces.InterfaceWithInt;
+
+public class WithInt {
+
+    public static class WithIntImplementation implements InterfaceWithInt {
+        @Override
+        public int convert(int inputInt) {
+            return inputInt;
+        }
+    }
+
+    public static int main(String[] args) {
+        WithIntImplementation withInt = new WithIntImplementation();
+        return withInt.convert(1);
+    }
+}

--- a/translator/src/test/java/com/mirego/interop/java/test/interfaces/WithList.java
+++ b/translator/src/test/java/com/mirego/interop/java/test/interfaces/WithList.java
@@ -1,0 +1,21 @@
+package com.mirego.interop.java.test.interfaces;
+
+import com.mirego.interop.kotlin.test.interfaces.InterfaceWithList;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class WithList {
+
+    public static class WithListImplementation<E> implements InterfaceWithList {
+        @Override
+        public List convert(List inputList) {
+            return inputList;
+        }
+    }
+
+    public static List main(String[] args) {
+        WithListImplementation withList = new WithListImplementation<Integer>();
+        return withList.convert(Arrays.asList(Integer.valueOf(1)));
+    }
+}

--- a/translator/src/test/java/com/mirego/interop/java/test/interfaces/WithNullableInt.java
+++ b/translator/src/test/java/com/mirego/interop/java/test/interfaces/WithNullableInt.java
@@ -1,0 +1,18 @@
+package com.mirego.interop.java.test.interfaces;
+
+import com.mirego.interop.kotlin.test.interfaces.InterfaceWithNullableInt;
+
+public class WithNullableInt {
+
+    public static class WithNullableIntImplementation implements InterfaceWithNullableInt {
+        @Override
+        public Integer convert(Integer inputNullableInteger) {
+            return inputNullableInteger;
+        }
+    }
+
+    public static Integer main(String[] args) {
+        WithNullableIntImplementation withNullableInt = new WithNullableIntImplementation();
+        return withNullableInt.convert((Integer) 1);
+    }
+}

--- a/translator/src/test/java/com/mirego/interop/java/test/nullsafety/WithDoubleBangOperator.java
+++ b/translator/src/test/java/com/mirego/interop/java/test/nullsafety/WithDoubleBangOperator.java
@@ -1,0 +1,13 @@
+package com.mirego.interop.java.test.nullsafety;
+
+import com.mirego.interop.kotlin.test.nullsafety.ClassForNullSafety;
+
+public class WithDoubleBangOperator {
+
+    public static String main(String[] args) {
+
+        ClassForNullSafety classForNullSafety = new ClassForNullSafety();
+
+        return classForNullSafety.doubleBang();
+    }
+}

--- a/translator/src/test/java/com/mirego/interop/java/test/objects/StaticMethodWithGenericParamWithAnnotation.java
+++ b/translator/src/test/java/com/mirego/interop/java/test/objects/StaticMethodWithGenericParamWithAnnotation.java
@@ -1,0 +1,11 @@
+package com.mirego.interop.java.test.objects;
+
+import com.mirego.interop.kotlin.test.objects.ObjectWithMethod;
+
+public class StaticMethodWithGenericParamWithAnnotation {
+
+    public static String main(String[] args) {
+        String testString = "stringGeneric";
+        return ObjectWithMethod.staticMethodWithGenericParam(testString);
+    }
+}

--- a/translator/src/test/java/com/mirego/interop/java/test/objects/StaticMethodWithListParamWithAnnotation.java
+++ b/translator/src/test/java/com/mirego/interop/java/test/objects/StaticMethodWithListParamWithAnnotation.java
@@ -1,0 +1,15 @@
+package com.mirego.interop.java.test.objects;
+
+import com.mirego.interop.kotlin.test.objects.ObjectWithMethod;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class StaticMethodWithListParamWithAnnotation {
+
+    public static List<Integer> main(String[] args) {
+        List<Integer> list = Arrays.asList(1, 2);
+        List<Integer> returnValue = ObjectWithMethod.staticMethodWithListParamWithAnnotation(list);
+        return returnValue;
+    }
+}

--- a/translator/src/test/java/com/mirego/interop/java/test/objects/StaticMethodWithStringParamWithAnnotation.java
+++ b/translator/src/test/java/com/mirego/interop/java/test/objects/StaticMethodWithStringParamWithAnnotation.java
@@ -1,0 +1,11 @@
+package com.mirego.interop.java.test.objects;
+
+import com.mirego.interop.kotlin.test.objects.ObjectWithMethod;
+
+public class StaticMethodWithStringParamWithAnnotation {
+
+  public static String main(String[] args) {
+    String returnValue = ObjectWithMethod.staticMethodWithStringParamWithAnnotation("stringAsParam");
+    return returnValue;
+  }
+}

--- a/translator/src/test/java/com/mirego/interop/java/test/objects/StaticMethodWithoutParamWithAnnotation.java
+++ b/translator/src/test/java/com/mirego/interop/java/test/objects/StaticMethodWithoutParamWithAnnotation.java
@@ -1,0 +1,11 @@
+package com.mirego.interop.java.test.objects;
+
+import com.mirego.interop.kotlin.test.objects.ObjectWithMethod;
+
+public class StaticMethodWithoutParamWithAnnotation {
+
+  public static String main(String[] args) {
+    String returnValue = ObjectWithMethod.staticMethodWithoutParamWithAnnotation();
+    return returnValue;
+  }
+}

--- a/translator/src/test/java/com/mirego/interop/java/test/property/AccessPropertyWithNilChk.java
+++ b/translator/src/test/java/com/mirego/interop/java/test/property/AccessPropertyWithNilChk.java
@@ -1,0 +1,17 @@
+package com.mirego.interop.java.test.property;
+
+import com.mirego.interop.kotlin.test.property.ClassWithStringProperty;
+
+public class AccessPropertyWithNilChk {
+
+    public static String main(String[] args) {
+        ClassWithStringProperty a = new ClassWithStringProperty("testString");
+        return getThePropertyValue(a);
+    }
+
+    private static String getThePropertyValue(ClassWithStringProperty sourceForTheStringProperty) {
+        // sourceForTheStringProperty may be null here so the compiler should generate nil_chk
+        return sourceForTheStringProperty.getStringProperty();
+    }
+
+}

--- a/translator/src/test/java/com/mirego/interop/java/test/property/BackingFieldWithCustomGetter.java
+++ b/translator/src/test/java/com/mirego/interop/java/test/property/BackingFieldWithCustomGetter.java
@@ -1,0 +1,13 @@
+package com.mirego.interop.java.test.property;
+
+import com.mirego.interop.kotlin.test.property.ClassWithBackingFieldCustomGetter;
+
+public class BackingFieldWithCustomGetter {
+
+    public static String main(String[] args) {
+
+        ClassWithBackingFieldCustomGetter classWithBackingFieldCustomGetter = new ClassWithBackingFieldCustomGetter();
+
+        return classWithBackingFieldCustomGetter.getBackedField();
+    }
+}

--- a/translator/src/test/java/com/mirego/interop/java/test/property/BackingFieldWithCustomSetter.java
+++ b/translator/src/test/java/com/mirego/interop/java/test/property/BackingFieldWithCustomSetter.java
@@ -1,0 +1,13 @@
+package com.mirego.interop.java.test.property;
+
+import com.mirego.interop.kotlin.test.property.ClassWithBackingFieldCustomSetter;
+
+public class BackingFieldWithCustomSetter {
+
+    public static String main(String[] args) {
+
+        ClassWithBackingFieldCustomSetter classWithBackingFieldCustomGetter = new ClassWithBackingFieldCustomSetter();
+        classWithBackingFieldCustomGetter.setBackedField("backed");
+        return classWithBackingFieldCustomGetter.getBackedField();
+    }
+}

--- a/translator/src/test/java/com/mirego/interop/java/test/property/BackingPropertyWithCustomGetter.java
+++ b/translator/src/test/java/com/mirego/interop/java/test/property/BackingPropertyWithCustomGetter.java
@@ -1,0 +1,13 @@
+package com.mirego.interop.java.test.property;
+
+import com.mirego.interop.kotlin.test.property.ClassWithBackingPropertyCustomGetter;
+
+public class BackingPropertyWithCustomGetter {
+
+    public static String main(String[] args) {
+
+        ClassWithBackingPropertyCustomGetter classWithBackingPropertyCustomGetter = new ClassWithBackingPropertyCustomGetter();
+
+        return classWithBackingPropertyCustomGetter.getBackedProperty();
+    }
+}

--- a/translator/src/test/java/com/mirego/interop/java/test/property/BackingPropertyWithCustomSetter.java
+++ b/translator/src/test/java/com/mirego/interop/java/test/property/BackingPropertyWithCustomSetter.java
@@ -1,0 +1,14 @@
+package com.mirego.interop.java.test.property;
+
+import com.mirego.interop.kotlin.test.property.ClassWithBackingPropertyCustomSetter;
+
+public class BackingPropertyWithCustomSetter {
+
+    public static String main(String[] args) {
+
+        ClassWithBackingPropertyCustomSetter classWithBackingPropertyCustomSetter = new ClassWithBackingPropertyCustomSetter();
+        classWithBackingPropertyCustomSetter.setBackedProperty("backed property");
+
+        return classWithBackingPropertyCustomSetter.getBackedProperty();
+    }
+}

--- a/translator/src/test/java/com/mirego/interop/java/test/property/BooleanProperty.java
+++ b/translator/src/test/java/com/mirego/interop/java/test/property/BooleanProperty.java
@@ -1,0 +1,13 @@
+package com.mirego.interop.java.test.property;
+
+import com.mirego.interop.kotlin.test.property.ClassWithBooleanProperty;
+
+public class BooleanProperty {
+
+    public static boolean main(String[] args) {
+
+        ClassWithBooleanProperty classWithBooleanProperty = new ClassWithBooleanProperty(false);
+
+        return classWithBooleanProperty.getBooleanProperty();
+    }
+}

--- a/translator/src/test/java/com/mirego/interop/java/test/property/ByteProperty.java
+++ b/translator/src/test/java/com/mirego/interop/java/test/property/ByteProperty.java
@@ -1,0 +1,13 @@
+package com.mirego.interop.java.test.property;
+
+import com.mirego.interop.kotlin.test.property.ClassWithByteProperty;
+
+public class ByteProperty {
+
+    public static byte main(String[] args) {
+
+        ClassWithByteProperty classWithByteProperty = new ClassWithByteProperty((byte) 1);
+
+        return classWithByteProperty.getByteProperty();
+    }
+}

--- a/translator/src/test/java/com/mirego/interop/java/test/property/CharProperty.java
+++ b/translator/src/test/java/com/mirego/interop/java/test/property/CharProperty.java
@@ -1,0 +1,13 @@
+package com.mirego.interop.java.test.property;
+
+import com.mirego.interop.kotlin.test.property.ClassWithCharProperty;
+
+public class CharProperty {
+
+    public static char main(String[] args) {
+
+        ClassWithCharProperty classWithCharProperty = new ClassWithCharProperty('a');
+
+        return classWithCharProperty.getCharProperty();
+    }
+}

--- a/translator/src/test/java/com/mirego/interop/java/test/property/CharSequenceProperty.java
+++ b/translator/src/test/java/com/mirego/interop/java/test/property/CharSequenceProperty.java
@@ -1,0 +1,11 @@
+package com.mirego.interop.java.test.property;
+
+import com.mirego.interop.kotlin.test.property.ClassWithCharSequenceProperty;
+
+public class CharSequenceProperty {
+
+    public static CharSequence main(String[] args) {
+        ClassWithCharSequenceProperty classWithCharSequenceProperty = new ClassWithCharSequenceProperty("1000");
+        return classWithCharSequenceProperty.getCharSequenceProperty();
+    }
+}

--- a/translator/src/test/java/com/mirego/interop/java/test/property/DoubleProperty.java
+++ b/translator/src/test/java/com/mirego/interop/java/test/property/DoubleProperty.java
@@ -1,0 +1,13 @@
+package com.mirego.interop.java.test.property;
+
+import com.mirego.interop.kotlin.test.property.ClassWithDoubleProperty;
+
+public class DoubleProperty {
+
+    public static double main(String[] args) {
+
+        ClassWithDoubleProperty classWithDoubleProperty = new ClassWithDoubleProperty(0.1);
+
+        return classWithDoubleProperty.getDoubleProperty();
+    }
+}

--- a/translator/src/test/java/com/mirego/interop/java/test/property/EscapedStringProperty.java
+++ b/translator/src/test/java/com/mirego/interop/java/test/property/EscapedStringProperty.java
@@ -1,0 +1,13 @@
+package com.mirego.interop.java.test.property;
+
+import com.mirego.interop.kotlin.test.property.ClassWithEscapedStringProperty;
+
+public class EscapedStringProperty {
+
+    public static String main(String[] args) {
+
+        ClassWithEscapedStringProperty classWithEscapedStringProperty = new ClassWithEscapedStringProperty("testString\n");
+
+        return classWithEscapedStringProperty.getEscapedString();
+    }
+}

--- a/translator/src/test/java/com/mirego/interop/java/test/property/FloatProperty.java
+++ b/translator/src/test/java/com/mirego/interop/java/test/property/FloatProperty.java
@@ -1,0 +1,13 @@
+package com.mirego.interop.java.test.property;
+
+import com.mirego.interop.kotlin.test.property.ClassWithFloatProperty;
+
+public class FloatProperty {
+
+    public static float main(String[] args) {
+
+        ClassWithFloatProperty classWithFloatProperty = new ClassWithFloatProperty(0.1f);
+
+        return classWithFloatProperty.getFloatProperty();
+    }
+}

--- a/translator/src/test/java/com/mirego/interop/java/test/property/IntProperty.java
+++ b/translator/src/test/java/com/mirego/interop/java/test/property/IntProperty.java
@@ -1,0 +1,13 @@
+package com.mirego.interop.java.test.property;
+
+import com.mirego.interop.kotlin.test.property.ClassWithIntProperty;
+
+public class IntProperty {
+
+    public static int main(String[] args) {
+
+        ClassWithIntProperty classWithIntProperty = new ClassWithIntProperty(1);
+
+        return classWithIntProperty.getIntProperty();
+    }
+}

--- a/translator/src/test/java/com/mirego/interop/java/test/property/LateInitializedProperty.java
+++ b/translator/src/test/java/com/mirego/interop/java/test/property/LateInitializedProperty.java
@@ -1,0 +1,13 @@
+package com.mirego.interop.java.test.property;
+
+import com.mirego.interop.kotlin.test.property.ClassWithLateInitializedProperty;
+
+public class LateInitializedProperty {
+
+    public static String main(String[] args) {
+
+        ClassWithLateInitializedProperty classWithBackingPropertyCustomSetter = new ClassWithLateInitializedProperty();
+
+        return classWithBackingPropertyCustomSetter.getLateInitializedProperty();
+    }
+}

--- a/translator/src/test/java/com/mirego/interop/java/test/property/LateNonInitializedProperty.java
+++ b/translator/src/test/java/com/mirego/interop/java/test/property/LateNonInitializedProperty.java
@@ -1,0 +1,13 @@
+package com.mirego.interop.java.test.property;
+
+import com.mirego.interop.kotlin.test.property.ClassWithLateNonInitializedProperty;
+
+public class LateNonInitializedProperty {
+
+    public static String main(String[] args) {
+
+        ClassWithLateNonInitializedProperty classWithLateNonInitializedProperty = new ClassWithLateNonInitializedProperty();
+
+        return classWithLateNonInitializedProperty.getLateNonInitializedProperty();
+    }
+}

--- a/translator/src/test/java/com/mirego/interop/java/test/property/ListProperty.java
+++ b/translator/src/test/java/com/mirego/interop/java/test/property/ListProperty.java
@@ -1,0 +1,16 @@
+package com.mirego.interop.java.test.property;
+
+import com.mirego.interop.kotlin.test.property.ClassWithListProperty;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class ListProperty {
+
+    public static List<String> main(String[] args) {
+
+        ClassWithListProperty classWithListProperty = new ClassWithListProperty(Arrays.asList("test", "string"));
+
+        return classWithListProperty.getListProperty();
+    }
+}

--- a/translator/src/test/java/com/mirego/interop/java/test/property/LongProperty.java
+++ b/translator/src/test/java/com/mirego/interop/java/test/property/LongProperty.java
@@ -1,0 +1,13 @@
+package com.mirego.interop.java.test.property;
+
+import com.mirego.interop.kotlin.test.property.ClassWithLongProperty;
+
+public class LongProperty {
+
+    public static long main(String[] args) {
+
+        ClassWithLongProperty classWithLongProperty = new ClassWithLongProperty(1);
+
+        return classWithLongProperty.getLongProperty();
+    }
+}

--- a/translator/src/test/java/com/mirego/interop/java/test/property/NullableBooleanProperty.java
+++ b/translator/src/test/java/com/mirego/interop/java/test/property/NullableBooleanProperty.java
@@ -1,0 +1,13 @@
+package com.mirego.interop.java.test.property;
+
+import com.mirego.interop.kotlin.test.property.ClassWithNullableBooleanProperty;
+
+public class NullableBooleanProperty {
+
+    public static boolean main(String[] args) {
+
+        ClassWithNullableBooleanProperty classWithNullableBooleanProperty = new ClassWithNullableBooleanProperty(null);
+
+        return classWithNullableBooleanProperty.getNullableBoolean();
+    }
+}

--- a/translator/src/test/java/com/mirego/interop/java/test/property/NullableProperty.java
+++ b/translator/src/test/java/com/mirego/interop/java/test/property/NullableProperty.java
@@ -1,0 +1,13 @@
+package com.mirego.interop.java.test.property;
+
+import com.mirego.interop.kotlin.test.property.ClassWithNullableProperty;
+
+public class NullableProperty {
+
+    public static String main(String[] args) {
+
+        ClassWithNullableProperty nullablePropertyClass = new ClassWithNullableProperty(null);
+
+        return nullablePropertyClass.getNullableProperty();
+    }
+}

--- a/translator/src/test/java/com/mirego/interop/java/test/property/PublicImmutablePropertyWithGeneratedGetter.java
+++ b/translator/src/test/java/com/mirego/interop/java/test/property/PublicImmutablePropertyWithGeneratedGetter.java
@@ -1,0 +1,13 @@
+package com.mirego.interop.java.test.property;
+
+import com.mirego.interop.kotlin.test.property.ClassWithPublicImmutableProperty;
+
+public class PublicImmutablePropertyWithGeneratedGetter {
+
+    public static String main(String[] args) {
+
+        ClassWithPublicImmutableProperty immutablePropertyClass = new ClassWithPublicImmutableProperty("immutableProperty");
+
+        return immutablePropertyClass.getImmutableProperty();
+    }
+}

--- a/translator/src/test/java/com/mirego/interop/java/test/property/PublicMutablePropertyWithGeneratedSetter.java
+++ b/translator/src/test/java/com/mirego/interop/java/test/property/PublicMutablePropertyWithGeneratedSetter.java
@@ -1,0 +1,13 @@
+package com.mirego.interop.java.test.property;
+
+import com.mirego.interop.kotlin.test.property.ClassWithPublicMutableProperty;
+
+public class PublicMutablePropertyWithGeneratedSetter {
+
+    public static String main(String[] args) {
+
+        ClassWithPublicMutableProperty mutablePropertyClass = new ClassWithPublicMutableProperty("mutableProperty");
+        mutablePropertyClass.setMutableProperty("mutatedMutableProperty");
+        return mutablePropertyClass.getMutableProperty();
+    }
+}

--- a/translator/src/test/java/com/mirego/interop/java/test/property/ShortProperty.java
+++ b/translator/src/test/java/com/mirego/interop/java/test/property/ShortProperty.java
@@ -1,0 +1,13 @@
+package com.mirego.interop.java.test.property;
+
+import com.mirego.interop.kotlin.test.property.ClassWithShortProperty;
+
+public class ShortProperty {
+
+    public static short main(String[] args) {
+
+        ClassWithShortProperty classWithShortProperty = new ClassWithShortProperty((short) 1);
+
+        return classWithShortProperty.getShortProperty();
+    }
+}

--- a/translator/src/test/java/com/mirego/interop/java/test/property/StringProperty.java
+++ b/translator/src/test/java/com/mirego/interop/java/test/property/StringProperty.java
@@ -1,0 +1,13 @@
+package com.mirego.interop.java.test.property;
+
+import com.mirego.interop.kotlin.test.property.ClassWithStringProperty;
+
+public class StringProperty {
+
+    public static String main(String[] args) {
+
+        ClassWithStringProperty classWithStringProperty = new ClassWithStringProperty("testString");
+
+        return classWithStringProperty.getStringProperty();
+    }
+}


### PR DESCRIPTION
We now support method call that used generics specific for that function instead of for the class.

Also fixed an issue with our switch case handling we could received expression that were not `SimpleName` instances but `QualifiedName` instances, so we got to the super class for both `Name` that supports what we need.

Sorry for the big PR, i was tired of the submodule for sharing tests, it made the workflow less than ideal. We will now have to copy manually tests between j2objc and j2js. The workflow improvements are worth it.

