### PR TITLE
Mirego/kinternship/2.7 method params

### DIFF
--- a/translator/src/main/java/com/google/devtools/j2objc/util/KotlinMetadataUtil.java
+++ b/translator/src/main/java/com/google/devtools/j2objc/util/KotlinMetadataUtil.java
@@ -4,15 +4,34 @@ import java.util.ArrayList;
 import java.util.List;
 
 import javax.lang.model.element.Element;
+import javax.lang.model.element.ExecutableElement;
 
 import kotlin.Metadata;
 import kotlinx.metadata.KmClass;
+import kotlinx.metadata.KmConstructor;
 import kotlinx.metadata.KmFunction;
 import kotlinx.metadata.KmValueParameter;
 import kotlinx.metadata.jvm.KotlinClassHeader;
 import kotlinx.metadata.jvm.KotlinClassMetadata;
 
 public class KotlinMetadataUtil {
+
+  public static List<String> getParameterNames(ExecutableElement element, String elementName) {
+    Element enclosingElement = element.getEnclosingElement();
+
+    List<String> parameters = new ArrayList<>();
+    if (ElementUtil.isConstructor(element)) {
+      KmClass kmClass = getClass(enclosingElement);
+      List<KmConstructor> constructors = kmClass.getConstructors();
+      for (KmValueParameter parameter : constructors.get(0).getValueParameters()) {
+        parameters.add(parameter.getName());
+      }
+    } else {
+      parameters = getFunctionParameterNames(enclosingElement, element.getSimpleName().toString());
+    }
+
+    return parameters;
+  }
 
   public static List<String> getFunctionParameterNames(Element enclosingElement, String functionName) {
     KmClass kmClass = getClass(enclosingElement);

--- a/translator/src/main/java/com/google/devtools/j2objc/util/NameTable.java
+++ b/translator/src/main/java/com/google/devtools/j2objc/util/NameTable.java
@@ -406,28 +406,22 @@ public class NameTable {
         first = appendParamKeyword(sb, param.asType(), delim, first);
       }
     }
-    for (VariableElement param : method.getParameters()) {
-      if (ElementUtil.isKotlinType(method)) {
-        if (ElementUtil.isStatic(method)) {
-          List<String> functionParams = KotlinMetadataUtil.getFunctionParameterNames(method.getEnclosingElement(), method.getSimpleName().toString());
+    if (ElementUtil.isKotlinType(method)) {
+      if (first && method.getSimpleName().toString().equals("<init>")) {
+        sb.append("With");
+      }
 
-          for (String parameter : functionParams) {
-            first = appendParamKeywordKotlin(sb, parameter, delim, first);
-          }
-          break;
-        }
+      List<String> functionParams = KotlinMetadataUtil.getParameterNames(method, method.getSimpleName().toString());
 
-        if (first && method.getSimpleName().toString().equals("<init>")) {
-          sb.append("With");
-        }
-
+      for (String parameter : functionParams) {
         if (name.startsWith("set") &&
             checkEnclosedElementsForField(declaringClass.getEnclosedElements(), name.substring(3)).isPresent()) {
           break;
         }
-
-        first = appendParamKeywordKotlin(sb, param.getSimpleName().toString(), delim, first);
-      } else {
+        first = appendParamKeywordKotlin(sb, parameter, delim, first);
+      }
+    } else {
+      for (VariableElement param : method.getParameters()) {
         first = appendParamKeyword(sb, param.asType(), delim, first);
       }
     }


### PR DESCRIPTION
## Description and motivation
- Added support for method parameters of primitive type for instance methods and constructor calls
## Work done
- added kotlin metadata extraction of constructor parameters names
- added translation special case of kotlin instance method
### Tasks
- [x] Instance method with parameters calls
- [x] Constructor with parameters calls
### Additional notes
## Result
- new ConcreteClassWithConstructor(5); -> [[CommonConcreteClassWithConstructor alloc] initWithIntParam:5];
- concreteClassWithoutConstructor.methodNativeParameters(5, false, 0.5); -> [concreteClassWithoutConstructor methodNativeParametersIntParam:5 boolParam:false doubleParam:0.5];