### PR TITLE
Support adapters between Collections returned by Kotlin and jre_emul collections

### DIFF
--- a/jre_emul/Classes/J2ObjC_common.h
+++ b/jre_emul/Classes/J2ObjC_common.h
@@ -286,8 +286,11 @@ typedef struct J2ObjCClass_t J2ObjCClass_t;
     extern const J2ObjCClass_t J2OBJC_CLASS_SYMBOL(name)
 
 //MIREGO kotlin interop >>
-    id <JavaUtilList> toJavaUtilList(NSArray<id>*);
-    id <JavaUtilListIterator> toJavaUtilListIterator(NSArray<id>*);
- //MIREGO <<
+void illegalAdapterMutableCallWithName(NSString *name);
+void unsupportedAdapterCallWithName(NSString *name);
+
+id <JavaUtilList> toJavaUtilList(NSArray<id>*);
+id <JavaUtilListIterator> toJavaUtilListIterator(NSArray<id>*);
+//MIREGO <<
 
 #endif // _J2OBJC_COMMON_H_

--- a/jre_emul/Classes/J2ObjC_common.h
+++ b/jre_emul/Classes/J2ObjC_common.h
@@ -25,6 +25,7 @@
 @class IOSClass;
 @class JavaLangRefWeakReference;
 @protocol JavaLangIterable;
+@protocol JavaUtilList;
 
 #ifndef __has_feature
 #define __has_feature(x) 0  // Compatibility with non-clang compilers.
@@ -279,5 +280,12 @@ typedef struct J2ObjCClass_t J2ObjCClass_t;
     ((__bridge Class)&(J2OBJC_CLASS_SYMBOL(name)))
 #define J2OBJC_CLASS_DECLARATION(name) \
     extern const J2ObjCClass_t J2OBJC_CLASS_SYMBOL(name)
+
+
+//MIREGO kotlin interop >>
+
+id <JavaUtilList> toJavaUtilList(NSArray<id>*);
+
+//MIREGO <<
 
 #endif // _J2OBJC_COMMON_H_

--- a/jre_emul/Classes/J2ObjC_common.h
+++ b/jre_emul/Classes/J2ObjC_common.h
@@ -281,11 +281,8 @@ typedef struct J2ObjCClass_t J2ObjCClass_t;
 #define J2OBJC_CLASS_DECLARATION(name) \
     extern const J2ObjCClass_t J2OBJC_CLASS_SYMBOL(name)
 
-
 //MIREGO kotlin interop >>
-
-id <JavaUtilList> toJavaUtilList(NSArray<id>*);
-
-//MIREGO <<
+    id <JavaUtilList> toJavaUtilList(NSArray<id>*);
+ //MIREGO <<
 
 #endif // _J2OBJC_COMMON_H_

--- a/jre_emul/Classes/J2ObjC_common.h
+++ b/jre_emul/Classes/J2ObjC_common.h
@@ -25,8 +25,11 @@
 @class IOSClass;
 @class JavaLangRefWeakReference;
 @protocol JavaLangIterable;
+
+//MIREGO kotlin interop >>
 @protocol JavaUtilListIterator;
 @protocol JavaUtilList;
+//MIREGO <<
 
 #ifndef __has_feature
 #define __has_feature(x) 0  // Compatibility with non-clang compilers.

--- a/jre_emul/Classes/J2ObjC_common.h
+++ b/jre_emul/Classes/J2ObjC_common.h
@@ -25,6 +25,7 @@
 @class IOSClass;
 @class JavaLangRefWeakReference;
 @protocol JavaLangIterable;
+@protocol JavaUtilListIterator;
 @protocol JavaUtilList;
 
 #ifndef __has_feature
@@ -283,6 +284,7 @@ typedef struct J2ObjCClass_t J2ObjCClass_t;
 
 //MIREGO kotlin interop >>
     id <JavaUtilList> toJavaUtilList(NSArray<id>*);
+    id <JavaUtilListIterator> toJavaUtilListIterator(NSArray<id>*);
  //MIREGO <<
 
 #endif // _J2OBJC_COMMON_H_

--- a/jre_emul/Classes/J2ObjC_common.m
+++ b/jre_emul/Classes/J2ObjC_common.m
@@ -30,10 +30,12 @@
 #import "java/lang/Throwable.h"
 #import "java/util/logging/Level.h"
 #import "java/util/logging/Logger.h"
-#import "java/util/ArrayList.h"
 #import "objc/runtime.h"
+
+//MIREGO kotlin interop >>
 #import "NSArrayToJavaUtilListAdapter.h"
 #import "NSEnumeratorToJavaUtilListIteratorAdapter.h"
+//MIREGO <<
 
 id JreThrowNullPointerException() {
   @throw create_JavaLangNullPointerException_init(); // NOLINT

--- a/jre_emul/Classes/J2ObjC_common.m
+++ b/jre_emul/Classes/J2ObjC_common.m
@@ -33,6 +33,7 @@
 #import "java/util/ArrayList.h"
 #import "objc/runtime.h"
 #import "NSArrayToJavaUtilListAdapter.h"
+#import "NSEnumeratorToJavaUtilListIteratorAdapter.h"
 
 id JreThrowNullPointerException() {
   @throw create_JavaLangNullPointerException_init(); // NOLINT
@@ -451,18 +452,14 @@ NSUInteger JreDefaultFastEnumeration(
 }
 //MIREGO kotlin interop >>
 
-id <JavaUtilList> toJavaUtilList( NSArray<id> *sourceArray){
- //   id <JavaUtilList> list = [[JavaUtilArrayList alloc] initWithInt:(jint)sourceArray.count];
-//    NSEnumerator *enumerator = [sourceArray objectEnumerator];
-//    id contentObject;
+id <JavaUtilList> toJavaUtilList(NSArray<id> *sourceArray){
+    return [[NSArrayToJavaUtilsListAdapter alloc ] initWithSourceArray:sourceArray];
+}
 
- //   while (contentObject = [enumerator nextObject]) {
-//       [list addWithId:contentObject];
- //   }
-
- //   return list;
-
-    return [[ NSArrayToJavaUtilsListAdapter alloc ] initWithSourceArray:sourceArray];
+id <JavaUtilListIterator> toJavaUtilListIterator(NSArray<id>* sourceArray) {
+    return [[NSEnumeratorToJavaUtilListIteratorAdapter alloc]
+            initWithSourceEnumerator:[sourceArray objectEnumerator]
+            sourceSize:sourceArray.count];
 }
 
 //MIREGO <<

--- a/jre_emul/Classes/J2ObjC_common.m
+++ b/jre_emul/Classes/J2ObjC_common.m
@@ -32,6 +32,7 @@
 #import "java/util/logging/Logger.h"
 #import "java/util/ArrayList.h"
 #import "objc/runtime.h"
+#import "NSArrayToJavaUtilListAdapter.h"
 
 id JreThrowNullPointerException() {
   @throw create_JavaLangNullPointerException_init(); // NOLINT
@@ -451,15 +452,17 @@ NSUInteger JreDefaultFastEnumeration(
 //MIREGO kotlin interop >>
 
 id <JavaUtilList> toJavaUtilList( NSArray<id> *sourceArray){
-    id <JavaUtilList> list = [[JavaUtilArrayList alloc] initWithInt:(jint)sourceArray.count];
-    NSEnumerator *enumerator = [sourceArray objectEnumerator];
-    id contentObject;
+ //   id <JavaUtilList> list = [[JavaUtilArrayList alloc] initWithInt:(jint)sourceArray.count];
+//    NSEnumerator *enumerator = [sourceArray objectEnumerator];
+//    id contentObject;
 
-    while (contentObject = [enumerator nextObject]) {
-       [list addWithId:contentObject];
-    }
+ //   while (contentObject = [enumerator nextObject]) {
+//       [list addWithId:contentObject];
+ //   }
 
-    return list;
+ //   return list;
+
+    return [[ NSArrayToJavaUtilsListAdapter alloc ] initWithSourceArray:sourceArray];
 }
 
 //MIREGO <<

--- a/jre_emul/Classes/J2ObjC_common.m
+++ b/jre_emul/Classes/J2ObjC_common.m
@@ -30,6 +30,7 @@
 #import "java/lang/Throwable.h"
 #import "java/util/logging/Level.h"
 #import "java/util/logging/Logger.h"
+#import "java/util/ArrayList.h"
 #import "objc/runtime.h"
 
 id JreThrowNullPointerException() {
@@ -447,3 +448,18 @@ NSUInteger JreDefaultFastEnumeration(
   }
   return objCount;
 }
+//MIREGO kotlin interop >>
+
+id <JavaUtilList> toJavaUtilList( NSArray<id> *sourceArray){
+    id <JavaUtilList> list = [[JavaUtilArrayList alloc] initWithInt:(jint)sourceArray.count];
+    NSEnumerator *enumerator = [sourceArray objectEnumerator];
+    id contentObject;
+
+    while (contentObject = [enumerator nextObject]) {
+       [list addWithId:contentObject];
+    }
+
+    return list;
+}
+
+//MIREGO <<

--- a/jre_emul/Classes/J2ObjC_common.m
+++ b/jre_emul/Classes/J2ObjC_common.m
@@ -454,6 +454,16 @@ NSUInteger JreDefaultFastEnumeration(
 }
 //MIREGO kotlin interop >>
 
+void illegalAdapterMutableCallWithName(NSString *name) {
+    NSString *message = [NSString stringWithFormat:@"Cannot call %@ on NSArrayToJavaUtilListAdapter, is not mutable", name];
+    @throw create_JavaLangException_initWithNSString_(message);
+}
+
+void unsupportedAdapterCallWithName(NSString *name) {
+    NSString *message = [NSString stringWithFormat:@"Cannot call %@ on NSArrayToJavaUtilListAdapter, not implemented yet", name];
+    @throw create_JavaLangException_initWithNSString_(message);
+}
+
 id <JavaUtilList> toJavaUtilList(NSArray<id> *sourceArray){
     return [[NSArrayToJavaUtilsListAdapter alloc ] initWithSourceArray:sourceArray];
 }

--- a/jre_emul/Classes/J2ObjC_common.m
+++ b/jre_emul/Classes/J2ObjC_common.m
@@ -465,7 +465,7 @@ void unsupportedAdapterCallWithName(NSString *name) {
 }
 
 id <JavaUtilList> toJavaUtilList(NSArray<id> *sourceArray){
-    return [[NSArrayToJavaUtilsListAdapter alloc ] initWithSourceArray:sourceArray];
+    return [[NSArrayToJavaUtilsListAdapter alloc] initWithSourceArray:sourceArray];
 }
 
 id <JavaUtilListIterator> toJavaUtilListIterator(NSArray<id>* sourceArray) {

--- a/jre_emul/Classes/NSArrayToJavaUtilListAdapter.h
+++ b/jre_emul/Classes/NSArrayToJavaUtilListAdapter.h
@@ -3,7 +3,13 @@
 #ifndef _NSArrayToJavaUtilListAdapter_H_
 #define _NSArrayToJavaUtilListAdapter_H_
 
-#import "J2ObjC_header.h"
+#import "J2ObjC_common.h"
+
+#if __has_feature(nullability)
+#pragma clang diagnostic push
+#pragma GCC diagnostic ignored "-Wnullability"
+#pragma GCC diagnostic ignored "-Wnullability-completeness"
+#endif
 
 #define RESTRICT_JavaUtilList 1
 #define INCLUDE_JavaUtilList 1

--- a/jre_emul/Classes/NSArrayToJavaUtilListAdapter.h
+++ b/jre_emul/Classes/NSArrayToJavaUtilListAdapter.h
@@ -1,4 +1,3 @@
-
 //MIREGO kotlin interop >>
 
 #ifndef _NSArrayToJavaUtilListAdapter_h_
@@ -86,7 +85,6 @@
 - (IOSObjectArray * __nonnull)toArrayWithNSObjectArray:(IOSObjectArray * __nonnull)objects;
 
 @end
-
 
 #endif /* _NSArrayToJavaUtilListAdapter_h_ */
 

--- a/jre_emul/Classes/NSArrayToJavaUtilListAdapter.h
+++ b/jre_emul/Classes/NSArrayToJavaUtilListAdapter.h
@@ -1,7 +1,8 @@
+
 //MIREGO kotlin interop >>
 
-#ifndef _NSArrayToJavaUtilListAdapter_H_
-#define _NSArrayToJavaUtilListAdapter_H_
+#ifndef _NSArrayToJavaUtilListAdapter_h_
+#define _NSArrayToJavaUtilListAdapter_h_
 
 #import "J2ObjC_common.h"
 
@@ -87,6 +88,6 @@
 @end
 
 
-#endif // _NSArrayToJavaUtilListAdapter_H_
+#endif /* _NSArrayToJavaUtilListAdapter_h_ */
 
 //MIREGO <<

--- a/jre_emul/Classes/NSArrayToJavaUtilListAdapter.h
+++ b/jre_emul/Classes/NSArrayToJavaUtilListAdapter.h
@@ -1,0 +1,86 @@
+//MIREGO kotlin interop >>
+
+#ifndef _NSArrayToJavaUtilListAdapter_H_
+#define _NSArrayToJavaUtilListAdapter_H_
+
+#import "J2ObjC_header.h"
+
+#define RESTRICT_JavaUtilList 1
+#define INCLUDE_JavaUtilList 1
+#include "java/util/List.h"
+
+@class IOSObjectArray;
+@protocol JavaUtilCollection;
+@protocol JavaUtilComparator;
+@protocol JavaUtilFunctionConsumer;
+@protocol JavaUtilFunctionPredicate;
+@protocol JavaUtilFunctionUnaryOperator;
+@protocol JavaUtilIterator;
+@protocol JavaUtilListIterator;
+@protocol JavaUtilSpliterator;
+@protocol JavaUtilStreamStream;
+
+@interface NSArrayToJavaUtilsListAdapter : NSObject < JavaUtilList >
+
+@property (strong, nonatomic) NSArray *sourceArray;
+
+- (instancetype)initWithSourceArray:(NSArray *)sourceArray;
+
+#pragma mark Public
+
+- (void)addWithInt:(jint)i
+            withId:(id)o;
+
+- (jboolean)addWithId:(id)o;
+
+- (jboolean)addAllWithJavaUtilCollection:(id<JavaUtilCollection> __nonnull)collection;
+
+- (jboolean)addAllWithInt:(jint)i
+   withJavaUtilCollection:(id<JavaUtilCollection> __nonnull)collection;
+
+- (void)clear;
+
+- (jboolean)containsWithId:(id)o;
+
+- (jboolean)containsAllWithJavaUtilCollection:(id<JavaUtilCollection> __nonnull)collection;
+
+- (id)getWithInt:(jint)i;
+
+- (jint)indexOfWithId:(id)o;
+
+- (jboolean)isEmpty;
+
+- (id<JavaUtilIterator> __nonnull)iterator;
+
+- (jint)lastIndexOfWithId:(id)o;
+
+- (id<JavaUtilListIterator> __nonnull)listIterator;
+
+- (id<JavaUtilListIterator> __nonnull)listIteratorWithInt:(jint)i;
+
+- (id)removeWithInt:(jint)i;
+
+- (jboolean)removeWithId:(id)o;
+
+- (jboolean)removeAllWithJavaUtilCollection:(id<JavaUtilCollection> __nonnull)collection;
+
+- (jboolean)retainAllWithJavaUtilCollection:(id<JavaUtilCollection> __nonnull)collection;
+
+- (id)setWithInt:(jint)i
+          withId:(id)o;
+
+- (jint)size;
+
+- (id<JavaUtilList> __nonnull)subListWithInt:(jint)i
+                                     withInt:(jint)i1;
+
+- (IOSObjectArray * __nonnull)toArray;
+
+- (IOSObjectArray * __nonnull)toArrayWithNSObjectArray:(IOSObjectArray * __nonnull)objects;
+
+@end
+
+
+#endif // _NSArrayToJavaUtilListAdapter_H_
+
+//MIREGO <<

--- a/jre_emul/Classes/NSArrayToJavaUtilListAdapter.m
+++ b/jre_emul/Classes/NSArrayToJavaUtilListAdapter.m
@@ -1,0 +1,140 @@
+
+#import "NSArrayToJavaUtilListAdapter.h"
+
+@implementation NSArrayToJavaUtilsListAdapter
+
+- (instancetype)initWithSourceArray:(NSArray *)sourceArray {
+    self = [super init];
+    if (self) {
+        _sourceArray = sourceArray;
+    }
+    return self;
+}
+
+- (jint)size {
+  return 0;
+}
+
+- (jboolean)isEmpty {
+  return false;
+}
+
+- (jboolean)containsWithId:(id)o {
+  return false;
+}
+
+- (id<JavaUtilIterator>)iterator {
+  return nil;
+}
+
+- (IOSObjectArray *)toArray {
+  return [IOSObjectArray arrayWithLength:0 type:NSObject_class_()];
+}
+
+- (jboolean)addWithId:(id)o {
+  return false;
+}
+
+- (jboolean)removeWithId:(id)o {
+  return false;
+}
+
+- (jboolean)addAllWithJavaUtilCollection:(id<JavaUtilCollection>)collection {
+  return false;
+}
+
+- (jboolean)addAllWithInt:(jint)i
+   withJavaUtilCollection:(id<JavaUtilCollection>)collection {
+  return false;
+}
+
+- (void)clear {
+}
+
+- (id)getWithInt:(jint)i {
+  return nil;
+}
+
+- (id)setWithInt:(jint)i
+          withId:(id)o {
+  return nil;
+}
+
+- (void)addWithInt:(jint)i
+            withId:(id)o {
+}
+
+- (id)removeWithInt:(jint)i {
+  return nil;
+}
+
+- (jint)indexOfWithId:(id)o {
+  return 0;
+}
+
+- (jint)lastIndexOfWithId:(id)o {
+  return 0;
+}
+
+- (id<JavaUtilListIterator>)listIterator {
+  return nil;
+}
+
+- (id<JavaUtilListIterator>)listIteratorWithInt:(jint)i {
+  return nil;
+}
+
+- (id<JavaUtilList>)subListWithInt:(jint)i
+                           withInt:(jint)i1 {
+  return nil;
+}
+
+- (jboolean)retainAllWithJavaUtilCollection:(id<JavaUtilCollection>)collection {
+  return false;
+}
+
+- (jboolean)removeAllWithJavaUtilCollection:(id<JavaUtilCollection>)collection {
+  return false;
+}
+
+- (jboolean)containsAllWithJavaUtilCollection:(id<JavaUtilCollection>)collection {
+  return false;
+}
+
+- (IOSObjectArray *)toArrayWithNSObjectArray:(IOSObjectArray *)objects {
+  return [IOSObjectArray arrayWithLength:0 type:NSObject_class_()];
+}
+
+- (void)replaceAllWithJavaUtilFunctionUnaryOperator:(id<JavaUtilFunctionUnaryOperator>)arg0 {
+  JavaUtilList_replaceAllWithJavaUtilFunctionUnaryOperator_(self, arg0);
+}
+
+- (void)sortWithJavaUtilComparator:(id<JavaUtilComparator>)arg0 {
+  JavaUtilList_sortWithJavaUtilComparator_(self, arg0);
+}
+
+- (id<JavaUtilSpliterator>)spliterator {
+  return JavaUtilList_spliterator(self);
+}
+
+- (jboolean)removeIfWithJavaUtilFunctionPredicate:(id<JavaUtilFunctionPredicate>)arg0 {
+  return JavaUtilCollection_removeIfWithJavaUtilFunctionPredicate_(self, arg0);
+}
+
+- (id<JavaUtilStreamStream>)stream {
+  return JavaUtilCollection_stream(self);
+}
+
+- (id<JavaUtilStreamStream>)parallelStream {
+  return JavaUtilCollection_parallelStream(self);
+}
+
+- (void)forEachWithJavaUtilFunctionConsumer:(id<JavaUtilFunctionConsumer>)arg0 {
+  JavaLangIterable_forEachWithJavaUtilFunctionConsumer_(self, arg0);
+}
+
+- (NSUInteger)countByEnumeratingWithState:(NSFastEnumerationState *)state objects:(__unsafe_unretained id *)stackbuf count:(NSUInteger)len {
+  return JreDefaultFastEnumeration(self, state, stackbuf);
+}
+
+@end

--- a/jre_emul/Classes/NSArrayToJavaUtilListAdapter.m
+++ b/jre_emul/Classes/NSArrayToJavaUtilListAdapter.m
@@ -32,33 +32,33 @@
 }
 
 - (IOSObjectArray *)toArray {
-    [self unsupportedCallWithName:@"toArray"];
+    unsupportedAdapterCallWithName(@"toArray");
     return [IOSObjectArray arrayWithLength:0 type:NSObject_class_()];
 }
 
 - (jboolean)addWithId:(id)o {
-    [self illegalCallWithName:@"addWithId"];
+    illegalAdapterMutableCallWithName(@"addWithId");
     return false;
 }
 
 - (jboolean)removeWithId:(id)o {
-    [self illegalCallWithName:@"removeWithId"];
+    illegalAdapterMutableCallWithName(@"removeWithId");
     return false;
 }
 
 - (jboolean)addAllWithJavaUtilCollection:(id<JavaUtilCollection>)collection {
-    [self illegalCallWithName:@"addAllWithJavaUtilCollection"];
+    illegalAdapterMutableCallWithName(@"addAllWithJavaUtilCollection");
     return false;
 }
 
 - (jboolean)addAllWithInt:(jint)i
    withJavaUtilCollection:(id<JavaUtilCollection>)collection {
-    [self illegalCallWithName:@"addAllWithInt"];
+    illegalAdapterMutableCallWithName(@"addAllWithInt");
     return false;
 }
 
 - (void)clear {
-    [self illegalCallWithName:@"clear"];
+    illegalAdapterMutableCallWithName(@"clear");
 }
 
 - (id)getWithInt:(jint)i {
@@ -67,17 +67,17 @@
 
 - (id)setWithInt:(jint)i
           withId:(id)o {
-    [self illegalCallWithName:@"setWithInt"];
+    illegalAdapterMutableCallWithName(@"setWithInt");
     return nil;
 }
 
 - (void)addWithInt:(jint)i
             withId:(id)o {
-    [self illegalCallWithName:@"addWithInt"];
+    illegalAdapterMutableCallWithName(@"addWithInt");
 }
 
 - (id)removeWithInt:(jint)i {
-    [self illegalCallWithName:@"removeWithInt"];
+    illegalAdapterMutableCallWithName(@"removeWithInt");
     return nil;
 }
 
@@ -86,7 +86,7 @@
 }
 
 - (jint)lastIndexOfWithId:(id)o {
-    [self unsupportedCallWithName:@"lastIndexOfWithId"];
+    unsupportedAdapterCallWithName(@"lastIndexOfWithId");
     return 0;
 }
 
@@ -95,7 +95,7 @@
 }
 
 - (id<JavaUtilListIterator>)listIteratorWithInt:(jint)i {
-    [self unsupportedCallWithName:@"listIteratorWithInt"];
+    unsupportedAdapterCallWithName(@"listIteratorWithInt");
     return nil;
 }
 
@@ -106,22 +106,22 @@
 }
 
 - (jboolean)retainAllWithJavaUtilCollection:(id<JavaUtilCollection>)collection {
-    [self illegalCallWithName:@"retainAllWithJavaUtilCollection"];
+    illegalAdapterMutableCallWithName(@"retainAllWithJavaUtilCollection");
     return false;
 }
 
 - (jboolean)removeAllWithJavaUtilCollection:(id<JavaUtilCollection>)collection {
-    [self illegalCallWithName:@"removeAllWithJavaUtilCollection"];
+    illegalAdapterMutableCallWithName(@"removeAllWithJavaUtilCollection");
     return false;
 }
 
 - (jboolean)containsAllWithJavaUtilCollection:(id<JavaUtilCollection>)collection {
-    [self unsupportedCallWithName:@"containsAllWithJavaUtilCollection"];
+    unsupportedAdapterCallWithName(@"containsAllWithJavaUtilCollection");
     return false;
 }
 
 - (IOSObjectArray *)toArrayWithNSObjectArray:(IOSObjectArray *)objects {
-    [self unsupportedCallWithName:@"toArrayWithNSObjectArray"];
+    unsupportedAdapterCallWithName(@"toArrayWithNSObjectArray");
     return [IOSObjectArray arrayWithLength:0 type:NSObject_class_()];
 }
 
@@ -138,7 +138,7 @@
 }
 
 - (jboolean)removeIfWithJavaUtilFunctionPredicate:(id<JavaUtilFunctionPredicate>)arg0 {
-    [self illegalCallWithName:@"removeIfWithJavaUtilFunctionPredicate"];
+    illegalAdapterMutableCallWithName(@"removeIfWithJavaUtilFunctionPredicate");
     return JavaUtilCollection_removeIfWithJavaUtilFunctionPredicate_(self, arg0);
 }
 
@@ -158,15 +158,7 @@
     return JreDefaultFastEnumeration(self, state, stackbuf);
 }
 
-- (void) illegalCallWithName:(NSString*)name {
-    NSString *message = [NSString stringWithFormat:@"Cannot call %@ on NSArrayToJavaUtilListAdapter, use NSMutableArrayToJavaUtilListAdapter", name];
-    @throw create_JavaLangException_initWithNSString_(message);
-}
 
-- (void) unsupportedCallWithName:(NSString*)name {
-    NSString *message = [NSString stringWithFormat:@"Cannot call %@ on NSArrayToJavaUtilListAdapter, not implemented yet", name];
-    @throw create_JavaLangException_initWithNSString_(message);
-}
 
 @end
 

--- a/jre_emul/Classes/NSArrayToJavaUtilListAdapter.m
+++ b/jre_emul/Classes/NSArrayToJavaUtilListAdapter.m
@@ -1,4 +1,6 @@
 
+//MIREGO kotlin interop >>
+
 #import "NSArrayToJavaUtilListAdapter.h"
 #import "NSEnumeratorToJavaUtilListIteratorAdapter.h"
 #include "java/lang/Exception.h"
@@ -167,3 +169,5 @@
 }
 
 @end
+
+//MIREGO <<

--- a/jre_emul/Classes/NSArrayToJavaUtilListAdapter.m
+++ b/jre_emul/Classes/NSArrayToJavaUtilListAdapter.m
@@ -1,4 +1,3 @@
-
 //MIREGO kotlin interop >>
 
 #import "NSArrayToJavaUtilListAdapter.h"
@@ -32,33 +31,33 @@
 }
 
 - (IOSObjectArray *)toArray {
-    unsupportedAdapterCallWithName(@"toArray");
+    unsupportedAdapterCallWithName(NSStringFromSelector(_cmd));
     return [IOSObjectArray arrayWithLength:0 type:NSObject_class_()];
 }
 
 - (jboolean)addWithId:(id)o {
-    illegalAdapterMutableCallWithName(@"addWithId");
+    illegalAdapterMutableCallWithName(NSStringFromSelector(_cmd));
     return false;
 }
 
 - (jboolean)removeWithId:(id)o {
-    illegalAdapterMutableCallWithName(@"removeWithId");
+    illegalAdapterMutableCallWithName(NSStringFromSelector(_cmd));
     return false;
 }
 
 - (jboolean)addAllWithJavaUtilCollection:(id<JavaUtilCollection>)collection {
-    illegalAdapterMutableCallWithName(@"addAllWithJavaUtilCollection");
+    illegalAdapterMutableCallWithName(NSStringFromSelector(_cmd));
     return false;
 }
 
 - (jboolean)addAllWithInt:(jint)i
    withJavaUtilCollection:(id<JavaUtilCollection>)collection {
-    illegalAdapterMutableCallWithName(@"addAllWithInt");
+    illegalAdapterMutableCallWithName(NSStringFromSelector(_cmd));
     return false;
 }
 
 - (void)clear {
-    illegalAdapterMutableCallWithName(@"clear");
+    illegalAdapterMutableCallWithName(NSStringFromSelector(_cmd));
 }
 
 - (id)getWithInt:(jint)i {
@@ -67,17 +66,17 @@
 
 - (id)setWithInt:(jint)i
           withId:(id)o {
-    illegalAdapterMutableCallWithName(@"setWithInt");
+    illegalAdapterMutableCallWithName(NSStringFromSelector(_cmd));
     return nil;
 }
 
 - (void)addWithInt:(jint)i
             withId:(id)o {
-    illegalAdapterMutableCallWithName(@"addWithInt");
+    illegalAdapterMutableCallWithName(NSStringFromSelector(_cmd));
 }
 
 - (id)removeWithInt:(jint)i {
-    illegalAdapterMutableCallWithName(@"removeWithInt");
+    illegalAdapterMutableCallWithName(NSStringFromSelector(_cmd));
     return nil;
 }
 
@@ -86,7 +85,7 @@
 }
 
 - (jint)lastIndexOfWithId:(id)o {
-    unsupportedAdapterCallWithName(@"lastIndexOfWithId");
+    unsupportedAdapterCallWithName(NSStringFromSelector(_cmd));
     return 0;
 }
 
@@ -95,7 +94,7 @@
 }
 
 - (id<JavaUtilListIterator>)listIteratorWithInt:(jint)i {
-    unsupportedAdapterCallWithName(@"listIteratorWithInt");
+    unsupportedAdapterCallWithName(NSStringFromSelector(_cmd));
     return nil;
 }
 
@@ -106,22 +105,22 @@
 }
 
 - (jboolean)retainAllWithJavaUtilCollection:(id<JavaUtilCollection>)collection {
-    illegalAdapterMutableCallWithName(@"retainAllWithJavaUtilCollection");
+    illegalAdapterMutableCallWithName(NSStringFromSelector(_cmd));
     return false;
 }
 
 - (jboolean)removeAllWithJavaUtilCollection:(id<JavaUtilCollection>)collection {
-    illegalAdapterMutableCallWithName(@"removeAllWithJavaUtilCollection");
+    illegalAdapterMutableCallWithName(NSStringFromSelector(_cmd));
     return false;
 }
 
 - (jboolean)containsAllWithJavaUtilCollection:(id<JavaUtilCollection>)collection {
-    unsupportedAdapterCallWithName(@"containsAllWithJavaUtilCollection");
+    unsupportedAdapterCallWithName(NSStringFromSelector(_cmd));
     return false;
 }
 
 - (IOSObjectArray *)toArrayWithNSObjectArray:(IOSObjectArray *)objects {
-    unsupportedAdapterCallWithName(@"toArrayWithNSObjectArray");
+    unsupportedAdapterCallWithName(NSStringFromSelector(_cmd));
     return [IOSObjectArray arrayWithLength:0 type:NSObject_class_()];
 }
 
@@ -138,7 +137,7 @@
 }
 
 - (jboolean)removeIfWithJavaUtilFunctionPredicate:(id<JavaUtilFunctionPredicate>)arg0 {
-    illegalAdapterMutableCallWithName(@"removeIfWithJavaUtilFunctionPredicate");
+    illegalAdapterMutableCallWithName(NSStringFromSelector(_cmd));
     return JavaUtilCollection_removeIfWithJavaUtilFunctionPredicate_(self, arg0);
 }
 
@@ -157,8 +156,6 @@
 - (NSUInteger)countByEnumeratingWithState:(NSFastEnumerationState *)state objects:(__unsafe_unretained id *)stackbuf count:(NSUInteger)len {
     return JreDefaultFastEnumeration(self, state, stackbuf);
 }
-
-
 
 @end
 

--- a/jre_emul/Classes/NSArrayToJavaUtilListAdapter.m
+++ b/jre_emul/Classes/NSArrayToJavaUtilListAdapter.m
@@ -1,5 +1,7 @@
 
 #import "NSArrayToJavaUtilListAdapter.h"
+#import "NSEnumeratorToJavaUtilListIteratorAdapter.h"
+#include "java/lang/Exception.h"
 
 @implementation NSArrayToJavaUtilsListAdapter
 
@@ -12,129 +14,156 @@
 }
 
 - (jint)size {
-  return 0;
+    return (jint)_sourceArray.count;
 }
 
 - (jboolean)isEmpty {
-  return false;
+    return _sourceArray.count == 0;
 }
 
 - (jboolean)containsWithId:(id)o {
-  return false;
+    return [_sourceArray containsObject:o];
 }
 
 - (id<JavaUtilIterator>)iterator {
-  return nil;
+    return toJavaUtilListIterator(_sourceArray);
 }
 
 - (IOSObjectArray *)toArray {
-  return [IOSObjectArray arrayWithLength:0 type:NSObject_class_()];
+    [self unsupportedCallWithName:@"toArray"];
+    return [IOSObjectArray arrayWithLength:0 type:NSObject_class_()];
 }
 
 - (jboolean)addWithId:(id)o {
-  return false;
+    [self illegalCallWithName:@"addWithId"];
+    return false;
 }
 
 - (jboolean)removeWithId:(id)o {
-  return false;
+    [self illegalCallWithName:@"removeWithId"];
+    return false;
 }
 
 - (jboolean)addAllWithJavaUtilCollection:(id<JavaUtilCollection>)collection {
-  return false;
+    [self illegalCallWithName:@"addAllWithJavaUtilCollection"];
+    return false;
 }
 
 - (jboolean)addAllWithInt:(jint)i
    withJavaUtilCollection:(id<JavaUtilCollection>)collection {
-  return false;
+    [self illegalCallWithName:@"addAllWithInt"];
+    return false;
 }
 
 - (void)clear {
+    [self illegalCallWithName:@"clear"];
 }
 
 - (id)getWithInt:(jint)i {
-  return nil;
+    return [_sourceArray objectAtIndex:i];
 }
 
 - (id)setWithInt:(jint)i
           withId:(id)o {
-  return nil;
+    [self illegalCallWithName:@"setWithInt"];
+    return nil;
 }
 
 - (void)addWithInt:(jint)i
             withId:(id)o {
+    [self illegalCallWithName:@"addWithInt"];
 }
 
 - (id)removeWithInt:(jint)i {
-  return nil;
+    [self illegalCallWithName:@"removeWithInt"];
+    return nil;
 }
 
 - (jint)indexOfWithId:(id)o {
-  return 0;
+    return (jint)[_sourceArray indexOfObject:o];
 }
 
 - (jint)lastIndexOfWithId:(id)o {
-  return 0;
+    [self unsupportedCallWithName:@"lastIndexOfWithId"];
+    return 0;
 }
 
 - (id<JavaUtilListIterator>)listIterator {
-  return nil;
+    return toJavaUtilListIterator(_sourceArray);
 }
 
 - (id<JavaUtilListIterator>)listIteratorWithInt:(jint)i {
-  return nil;
+    [self unsupportedCallWithName:@"listIteratorWithInt"];
+    return nil;
 }
 
 - (id<JavaUtilList>)subListWithInt:(jint)i
                            withInt:(jint)i1 {
-  return nil;
+    NSArray *subArray = [_sourceArray subarrayWithRange:NSMakeRange(i, i1 - i)];
+    return toJavaUtilList(subArray);
 }
 
 - (jboolean)retainAllWithJavaUtilCollection:(id<JavaUtilCollection>)collection {
-  return false;
+    [self illegalCallWithName:@"retainAllWithJavaUtilCollection"];
+    return false;
 }
 
 - (jboolean)removeAllWithJavaUtilCollection:(id<JavaUtilCollection>)collection {
-  return false;
+    [self illegalCallWithName:@"removeAllWithJavaUtilCollection"];
+    return false;
 }
 
 - (jboolean)containsAllWithJavaUtilCollection:(id<JavaUtilCollection>)collection {
-  return false;
+    [self unsupportedCallWithName:@"containsAllWithJavaUtilCollection"];
+    return false;
 }
 
 - (IOSObjectArray *)toArrayWithNSObjectArray:(IOSObjectArray *)objects {
-  return [IOSObjectArray arrayWithLength:0 type:NSObject_class_()];
+    [self unsupportedCallWithName:@"toArrayWithNSObjectArray"];
+    return [IOSObjectArray arrayWithLength:0 type:NSObject_class_()];
 }
 
 - (void)replaceAllWithJavaUtilFunctionUnaryOperator:(id<JavaUtilFunctionUnaryOperator>)arg0 {
-  JavaUtilList_replaceAllWithJavaUtilFunctionUnaryOperator_(self, arg0);
+    JavaUtilList_replaceAllWithJavaUtilFunctionUnaryOperator_(self, arg0);
 }
 
 - (void)sortWithJavaUtilComparator:(id<JavaUtilComparator>)arg0 {
-  JavaUtilList_sortWithJavaUtilComparator_(self, arg0);
+    JavaUtilList_sortWithJavaUtilComparator_(self, arg0);
 }
 
 - (id<JavaUtilSpliterator>)spliterator {
-  return JavaUtilList_spliterator(self);
+    return JavaUtilList_spliterator(self);
 }
 
 - (jboolean)removeIfWithJavaUtilFunctionPredicate:(id<JavaUtilFunctionPredicate>)arg0 {
-  return JavaUtilCollection_removeIfWithJavaUtilFunctionPredicate_(self, arg0);
+    [self illegalCallWithName:@"removeIfWithJavaUtilFunctionPredicate"];
+    return JavaUtilCollection_removeIfWithJavaUtilFunctionPredicate_(self, arg0);
 }
 
 - (id<JavaUtilStreamStream>)stream {
-  return JavaUtilCollection_stream(self);
+    return JavaUtilCollection_stream(self);
 }
 
 - (id<JavaUtilStreamStream>)parallelStream {
-  return JavaUtilCollection_parallelStream(self);
+    return JavaUtilCollection_parallelStream(self);
 }
 
 - (void)forEachWithJavaUtilFunctionConsumer:(id<JavaUtilFunctionConsumer>)arg0 {
-  JavaLangIterable_forEachWithJavaUtilFunctionConsumer_(self, arg0);
+    JavaLangIterable_forEachWithJavaUtilFunctionConsumer_(self, arg0);
 }
 
 - (NSUInteger)countByEnumeratingWithState:(NSFastEnumerationState *)state objects:(__unsafe_unretained id *)stackbuf count:(NSUInteger)len {
-  return JreDefaultFastEnumeration(self, state, stackbuf);
+    return JreDefaultFastEnumeration(self, state, stackbuf);
+}
+
+- (void) illegalCallWithName:(NSString*)name {
+    NSString *message = [NSString stringWithFormat:@"Cannot call %@ on NSArrayToJavaUtilListAdapter, use NSMutableArrayToJavaUtilListAdapter", name];
+    @throw create_JavaLangException_initWithNSString_(message);
+}
+
+- (void) unsupportedCallWithName:(NSString*)name {
+    NSString *message = [NSString stringWithFormat:@"Cannot call %@ on NSArrayToJavaUtilListAdapter, not implemented yet", name];
+    @throw create_JavaLangException_initWithNSString_(message);
 }
 
 @end

--- a/jre_emul/Classes/NSEnumeratorToJavaUtilListIteratorAdapter.h
+++ b/jre_emul/Classes/NSEnumeratorToJavaUtilListIteratorAdapter.h
@@ -1,4 +1,3 @@
-
 //MIREGO kotlin interop >>
 
 #ifndef _NSEnumeratorToJavaUtilListIteratorAdapter_h

--- a/jre_emul/Classes/NSEnumeratorToJavaUtilListIteratorAdapter.h
+++ b/jre_emul/Classes/NSEnumeratorToJavaUtilListIteratorAdapter.h
@@ -1,0 +1,54 @@
+//
+//  NSEnumeratorToJavaUtilIteratorAdapter.h
+//  jre_emul
+//
+//  Created by Guillaume Audet on 2021-04-19.
+//
+
+#ifndef NSEnumeratorToJavaUtilListIteratorAdapter_h
+#define NSEnumeratorToJavaUtilListIteratorAdapter_h
+
+#import "J2ObjC_common.h"
+
+#if __has_feature(nullability)
+#pragma clang diagnostic push
+#pragma GCC diagnostic ignored "-Wnullability"
+#pragma GCC diagnostic ignored "-Wnullability-completeness"
+#endif
+
+#include "java/util/ListIterator.h"
+
+@protocol JavaUtilListIterator;
+
+@interface NSEnumeratorToJavaUtilListIteratorAdapter : NSObject < JavaUtilListIterator >
+
+@property (strong, nonatomic) NSEnumerator *sourceEnumerator;
+@property (readonly) NSUInteger sourceSize;
+@property jint currentIndex;
+
+#pragma mark Public
+
+- (instancetype)initWithSourceEnumerator:(NSEnumerator *)sourceEnumerator
+                              sourceSize:(NSUInteger)sourceSize;
+
+- (void)addWithId:(id)o;
+
+- (jboolean)hasNext;
+
+- (jboolean)hasPrevious;
+
+- (id)next;
+
+- (jint)nextIndex;
+
+- (id)previous;
+
+- (jint)previousIndex;
+
+- (void)remove;
+
+- (void)setWithId:(id)o;
+
+@end
+
+#endif /* NSEnumeratorToJavaUtilListIteratorAdapter_h */

--- a/jre_emul/Classes/NSEnumeratorToJavaUtilListIteratorAdapter.h
+++ b/jre_emul/Classes/NSEnumeratorToJavaUtilListIteratorAdapter.h
@@ -1,12 +1,8 @@
-//
-//  NSEnumeratorToJavaUtilIteratorAdapter.h
-//  jre_emul
-//
-//  Created by Guillaume Audet on 2021-04-19.
-//
 
-#ifndef NSEnumeratorToJavaUtilListIteratorAdapter_h
-#define NSEnumeratorToJavaUtilListIteratorAdapter_h
+//MIREGO kotlin interop >>
+
+#ifndef _NSEnumeratorToJavaUtilListIteratorAdapter_h
+#define _NSEnumeratorToJavaUtilListIteratorAdapter_h
 
 #import "J2ObjC_common.h"
 
@@ -51,4 +47,6 @@
 
 @end
 
-#endif /* NSEnumeratorToJavaUtilListIteratorAdapter_h */
+#endif /* _NSEnumeratorToJavaUtilListIteratorAdapter_h */
+
+//MIREGO <<

--- a/jre_emul/Classes/NSEnumeratorToJavaUtilListIteratorAdapter.m
+++ b/jre_emul/Classes/NSEnumeratorToJavaUtilListIteratorAdapter.m
@@ -1,0 +1,72 @@
+
+#import "NSEnumeratorToJavaUtilListIteratorAdapter.h"
+#include "java/lang/Exception.h"
+
+@implementation NSEnumeratorToJavaUtilListIteratorAdapter
+
+- (instancetype)initWithSourceEnumerator:(NSEnumerator *)sourceEnumerator
+                              sourceSize:(NSUInteger)sourceSize{
+    self = [super init];
+    if (self) {
+        _sourceEnumerator = sourceEnumerator;
+        _sourceSize = sourceSize;
+        _currentIndex = 0;
+    }
+    return self;
+}
+
+- (jboolean)hasNext {
+  return _currentIndex < _sourceSize;
+}
+
+- (id)next {
+    _currentIndex++;
+  return [_sourceEnumerator nextObject];
+}
+
+- (jboolean)hasPrevious {
+    [self unsupportedCallWithName:@"hasPrevious"];
+  return false;
+}
+
+- (id)previous {
+    [self unsupportedCallWithName:@"previous"];
+  return nil;
+}
+
+- (jint)nextIndex {
+  return _currentIndex;
+}
+
+- (jint)previousIndex {
+    [self unsupportedCallWithName:@"previousIndex"];
+  return 0;
+}
+
+- (void)remove {
+    [self illegalCallWithName:@"remove"];
+}
+
+- (void)setWithId:(id)o {
+    [self illegalCallWithName:@"setWithId"];
+}
+
+- (void)addWithId:(id)o {
+    [self illegalCallWithName:@"addWithId"];
+}
+
+- (void)forEachRemainingWithJavaUtilFunctionConsumer:(id<JavaUtilFunctionConsumer>)arg0 {
+  JavaUtilIterator_forEachRemainingWithJavaUtilFunctionConsumer_(self, arg0);
+}
+
+- (void) illegalCallWithName:(NSString*)name {
+    NSString *message = [NSString stringWithFormat:@"Cannot call %@ on NSEnumeratorToJavaUtilListIteratorAdapter", name];
+    @throw create_JavaLangException_initWithNSString_(message);
+}
+
+- (void) unsupportedCallWithName:(NSString*)name {
+    NSString *message = [NSString stringWithFormat:@"Cannot call %@ on NSEnumeratorToJavaUtilListIteratorAdapter, not implemented yet", name];
+    @throw create_JavaLangException_initWithNSString_(message);
+}
+
+@end

--- a/jre_emul/Classes/NSEnumeratorToJavaUtilListIteratorAdapter.m
+++ b/jre_emul/Classes/NSEnumeratorToJavaUtilListIteratorAdapter.m
@@ -18,57 +18,47 @@
 }
 
 - (jboolean)hasNext {
-  return _currentIndex < _sourceSize;
+    return _currentIndex < _sourceSize;
 }
 
 - (id)next {
     _currentIndex++;
-  return [_sourceEnumerator nextObject];
+    return [_sourceEnumerator nextObject];
 }
 
 - (jboolean)hasPrevious {
-    [self unsupportedCallWithName:@"hasPrevious"];
-  return false;
+    unsupportedAdapterCallWithName(@"hasPrevious");
+    return false;
 }
 
 - (id)previous {
-    [self unsupportedCallWithName:@"previous"];
-  return nil;
+    unsupportedAdapterCallWithName(@"previous");
+    return nil;
 }
 
 - (jint)nextIndex {
-  return _currentIndex;
+    return _currentIndex;
 }
 
 - (jint)previousIndex {
-    [self unsupportedCallWithName:@"previousIndex"];
-  return 0;
+    unsupportedAdapterCallWithName(@"previousIndex");
+    return 0;
 }
 
 - (void)remove {
-    [self illegalCallWithName:@"remove"];
+    illegalAdapterMutableCallWithName(@"remove");
 }
 
 - (void)setWithId:(id)o {
-    [self illegalCallWithName:@"setWithId"];
+    illegalAdapterMutableCallWithName(@"setWithId");
 }
 
 - (void)addWithId:(id)o {
-    [self illegalCallWithName:@"addWithId"];
+    illegalAdapterMutableCallWithName(@"addWithId");
 }
 
 - (void)forEachRemainingWithJavaUtilFunctionConsumer:(id<JavaUtilFunctionConsumer>)arg0 {
-  JavaUtilIterator_forEachRemainingWithJavaUtilFunctionConsumer_(self, arg0);
-}
-
-- (void) illegalCallWithName:(NSString*)name {
-    NSString *message = [NSString stringWithFormat:@"Cannot call %@ on NSEnumeratorToJavaUtilListIteratorAdapter", name];
-    @throw create_JavaLangException_initWithNSString_(message);
-}
-
-- (void) unsupportedCallWithName:(NSString*)name {
-    NSString *message = [NSString stringWithFormat:@"Cannot call %@ on NSEnumeratorToJavaUtilListIteratorAdapter, not implemented yet", name];
-    @throw create_JavaLangException_initWithNSString_(message);
+    JavaUtilIterator_forEachRemainingWithJavaUtilFunctionConsumer_(self, arg0);
 }
 
 @end

--- a/jre_emul/Classes/NSEnumeratorToJavaUtilListIteratorAdapter.m
+++ b/jre_emul/Classes/NSEnumeratorToJavaUtilListIteratorAdapter.m
@@ -1,4 +1,3 @@
-
 //MIREGO kotlin interop >>
 
 #import "NSEnumeratorToJavaUtilListIteratorAdapter.h"
@@ -27,12 +26,12 @@
 }
 
 - (jboolean)hasPrevious {
-    unsupportedAdapterCallWithName(@"hasPrevious");
+    unsupportedAdapterCallWithName(NSStringFromSelector(_cmd));
     return false;
 }
 
 - (id)previous {
-    unsupportedAdapterCallWithName(@"previous");
+    unsupportedAdapterCallWithName(NSStringFromSelector(_cmd));
     return nil;
 }
 
@@ -41,20 +40,20 @@
 }
 
 - (jint)previousIndex {
-    unsupportedAdapterCallWithName(@"previousIndex");
+    unsupportedAdapterCallWithName(NSStringFromSelector(_cmd));
     return 0;
 }
 
 - (void)remove {
-    illegalAdapterMutableCallWithName(@"remove");
+    illegalAdapterMutableCallWithName(NSStringFromSelector(_cmd));
 }
 
 - (void)setWithId:(id)o {
-    illegalAdapterMutableCallWithName(@"setWithId");
+    illegalAdapterMutableCallWithName(NSStringFromSelector(_cmd));
 }
 
 - (void)addWithId:(id)o {
-    illegalAdapterMutableCallWithName(@"addWithId");
+    illegalAdapterMutableCallWithName(NSStringFromSelector(_cmd));
 }
 
 - (void)forEachRemainingWithJavaUtilFunctionConsumer:(id<JavaUtilFunctionConsumer>)arg0 {

--- a/jre_emul/Classes/NSEnumeratorToJavaUtilListIteratorAdapter.m
+++ b/jre_emul/Classes/NSEnumeratorToJavaUtilListIteratorAdapter.m
@@ -1,4 +1,6 @@
 
+//MIREGO kotlin interop >>
+
 #import "NSEnumeratorToJavaUtilListIteratorAdapter.h"
 #include "java/lang/Exception.h"
 
@@ -70,3 +72,5 @@
 }
 
 @end
+
+//MIREGO <<

--- a/jre_emul/JreEmulation.xcodeproj/project.pbxproj
+++ b/jre_emul/JreEmulation.xcodeproj/project.pbxproj
@@ -3399,6 +3399,7 @@
 		7A98C18924E20C8F00774306 /* Files2Test.m in Sources */ = {isa = PBXBuildFile; fileRef = 7A98C18624E20C8E00774306 /* Files2Test.m */; };
 		7A98C18A24E20C8F00774306 /* FilesTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 7A98C18724E20C8E00774306 /* FilesTest.m */; };
 		7A98C18C24E20CAF00774306 /* FileTypeDetectorTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 7A98C18B24E20CAF00774306 /* FileTypeDetectorTest.m */; };
+		B19F4EC8262DB54B003B9F32 /* NSArrayToJavaUtilListAdapter.m in Sources */ = {isa = PBXBuildFile; fileRef = B19F4EC6262DB54A003B9F32 /* NSArrayToJavaUtilListAdapter.m */; };
 		DE94F86A1F69A3B2006C59E4 /* InvocationTargetExceptionTest.m in Sources */ = {isa = PBXBuildFile; fileRef = DE94F8691F69A3B2006C59E4 /* InvocationTargetExceptionTest.m */; };
 		DE94F86C1F69A3D6006C59E4 /* ProxyTest.m in Sources */ = {isa = PBXBuildFile; fileRef = DE94F86B1F69A3D6006C59E4 /* ProxyTest.m */; };
 		FA1DD7A82154124E00D0B800 /* SSLSocketTest.m in Sources */ = {isa = PBXBuildFile; fileRef = FA1DD7A62154124E00D0B800 /* SSLSocketTest.m */; };
@@ -9332,6 +9333,8 @@
 		7A98C18624E20C8E00774306 /* Files2Test.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = Files2Test.m; path = libcore/java/nio/file/Files2Test.m; sourceTree = "<group>"; };
 		7A98C18724E20C8E00774306 /* FilesTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = FilesTest.m; path = libcore/java/nio/file/FilesTest.m; sourceTree = "<group>"; };
 		7A98C18B24E20CAF00774306 /* FileTypeDetectorTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = FileTypeDetectorTest.m; path = libcore/java/nio/file/spi/FileTypeDetectorTest.m; sourceTree = "<group>"; };
+		B19F4EC6262DB54A003B9F32 /* NSArrayToJavaUtilListAdapter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NSArrayToJavaUtilListAdapter.m; sourceTree = "<group>"; };
+		B19F4EC7262DB54A003B9F32 /* NSArrayToJavaUtilListAdapter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NSArrayToJavaUtilListAdapter.h; sourceTree = "<group>"; };
 		DE94F8691F69A3B2006C59E4 /* InvocationTargetExceptionTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = InvocationTargetExceptionTest.m; path = org/apache/harmony/tests/java/lang/reflect/InvocationTargetExceptionTest.m; sourceTree = "<group>"; };
 		DE94F86B1F69A3D6006C59E4 /* ProxyTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = ProxyTest.m; path = org/apache/harmony/tests/java/lang/reflect/ProxyTest.m; sourceTree = "<group>"; };
 		DE9C53841F6ADFAF000E8C71 /* ThreadPoolExecutorTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = ThreadPoolExecutorTest.m; path = libcore/java/util/concurrent/ThreadPoolExecutorTest.m; sourceTree = "<group>"; };
@@ -9738,6 +9741,8 @@
 		0661938A155848D70004DAFE /* Classes */ = {
 			isa = PBXGroup;
 			children = (
+				B19F4EC7262DB54A003B9F32 /* NSArrayToJavaUtilListAdapter.h */,
+				B19F4EC6262DB54A003B9F32 /* NSArrayToJavaUtilListAdapter.m */,
 				069FC49D1AF2A2290095A289 /* AbstractStringBuilder.h */,
 				0661AA7F19F848C800EFD1F5 /* AbstractStringBuilder.m */,
 				067228F9158FB0B3005318BD /* AccessibleObject.h */,
@@ -16666,6 +16671,7 @@
 				063BD7E9250597BD000819BB /* FilePermission.m in Sources */,
 				063BD7EA250597BD000819BB /* FileReader.m in Sources */,
 				063BD7EB250597BD000819BB /* FileURLConnection.m in Sources */,
+				B19F4EC8262DB54B003B9F32 /* NSArrayToJavaUtilListAdapter.m in Sources */,
 				063BD7EC250597BD000819BB /* FileWriter.m in Sources */,
 				063BD7ED250597BD000819BB /* Filter.m in Sources */,
 				063BDEDA2505BD43000819BB /* PathMatcher.m in Sources */,

--- a/jre_emul/JreEmulation.xcodeproj/project.pbxproj
+++ b/jre_emul/JreEmulation.xcodeproj/project.pbxproj
@@ -3400,6 +3400,7 @@
 		7A98C18A24E20C8F00774306 /* FilesTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 7A98C18724E20C8E00774306 /* FilesTest.m */; };
 		7A98C18C24E20CAF00774306 /* FileTypeDetectorTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 7A98C18B24E20CAF00774306 /* FileTypeDetectorTest.m */; };
 		B19F4EC8262DB54B003B9F32 /* NSArrayToJavaUtilListAdapter.m in Sources */ = {isa = PBXBuildFile; fileRef = B19F4EC6262DB54A003B9F32 /* NSArrayToJavaUtilListAdapter.m */; };
+		B19F4ED0262DD384003B9F32 /* NSEnumeratorToJavaUtilListIteratorAdapter.m in Sources */ = {isa = PBXBuildFile; fileRef = B19F4ECF262DD384003B9F32 /* NSEnumeratorToJavaUtilListIteratorAdapter.m */; };
 		DE94F86A1F69A3B2006C59E4 /* InvocationTargetExceptionTest.m in Sources */ = {isa = PBXBuildFile; fileRef = DE94F8691F69A3B2006C59E4 /* InvocationTargetExceptionTest.m */; };
 		DE94F86C1F69A3D6006C59E4 /* ProxyTest.m in Sources */ = {isa = PBXBuildFile; fileRef = DE94F86B1F69A3D6006C59E4 /* ProxyTest.m */; };
 		FA1DD7A82154124E00D0B800 /* SSLSocketTest.m in Sources */ = {isa = PBXBuildFile; fileRef = FA1DD7A62154124E00D0B800 /* SSLSocketTest.m */; };
@@ -9335,6 +9336,8 @@
 		7A98C18B24E20CAF00774306 /* FileTypeDetectorTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = FileTypeDetectorTest.m; path = libcore/java/nio/file/spi/FileTypeDetectorTest.m; sourceTree = "<group>"; };
 		B19F4EC6262DB54A003B9F32 /* NSArrayToJavaUtilListAdapter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = NSArrayToJavaUtilListAdapter.m; sourceTree = "<group>"; };
 		B19F4EC7262DB54A003B9F32 /* NSArrayToJavaUtilListAdapter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = NSArrayToJavaUtilListAdapter.h; sourceTree = "<group>"; };
+		B19F4ECF262DD384003B9F32 /* NSEnumeratorToJavaUtilListIteratorAdapter.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = NSEnumeratorToJavaUtilListIteratorAdapter.m; sourceTree = "<group>"; };
+		B19F4ED4262DD586003B9F32 /* NSEnumeratorToJavaUtilListIteratorAdapter.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NSEnumeratorToJavaUtilListIteratorAdapter.h; sourceTree = "<group>"; };
 		DE94F8691F69A3B2006C59E4 /* InvocationTargetExceptionTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = InvocationTargetExceptionTest.m; path = org/apache/harmony/tests/java/lang/reflect/InvocationTargetExceptionTest.m; sourceTree = "<group>"; };
 		DE94F86B1F69A3D6006C59E4 /* ProxyTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = ProxyTest.m; path = org/apache/harmony/tests/java/lang/reflect/ProxyTest.m; sourceTree = "<group>"; };
 		DE9C53841F6ADFAF000E8C71 /* ThreadPoolExecutorTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = ThreadPoolExecutorTest.m; path = libcore/java/util/concurrent/ThreadPoolExecutorTest.m; sourceTree = "<group>"; };
@@ -9741,8 +9744,6 @@
 		0661938A155848D70004DAFE /* Classes */ = {
 			isa = PBXGroup;
 			children = (
-				B19F4EC7262DB54A003B9F32 /* NSArrayToJavaUtilListAdapter.h */,
-				B19F4EC6262DB54A003B9F32 /* NSArrayToJavaUtilListAdapter.m */,
 				069FC49D1AF2A2290095A289 /* AbstractStringBuilder.h */,
 				0661AA7F19F848C800EFD1F5 /* AbstractStringBuilder.m */,
 				067228F9158FB0B3005318BD /* AccessibleObject.h */,
@@ -9863,6 +9864,8 @@
 				0628B43323D10F85008ADB82 /* NetworkInterface.m */,
 				063BDAE82505A184000819BB /* nio_util.h */,
 				063BDACE2505A181000819BB /* nio.h */,
+				B19F4EC7262DB54A003B9F32 /* NSArrayToJavaUtilListAdapter.h */,
+				B19F4EC6262DB54A003B9F32 /* NSArrayToJavaUtilListAdapter.m */,
 				064914341AC47ED000E98733 /* NSCopying+JavaCloneable.h */,
 				064914351AC47ED000E98733 /* NSCopying+JavaCloneable.m */,
 				2CBD9CBC174ABC0D008A0086 /* NSDataInputStream.h */,
@@ -9871,6 +9874,8 @@
 				2CBD9CBF174ABCF8008A0086 /* NSDataOutputStream.m */,
 				2CBD9CBA174A8BD7008A0086 /* NSDictionaryMap.h */,
 				2CBD9CBB174A8BD7008A0086 /* NSDictionaryMap.m */,
+				B19F4ED4262DD586003B9F32 /* NSEnumeratorToJavaUtilListIteratorAdapter.h */,
+				B19F4ECF262DD384003B9F32 /* NSEnumeratorToJavaUtilListIteratorAdapter.m */,
 				0671FC1518529E28005D9D56 /* NSNumber+JavaNumber.h */,
 				0671FC1618529E28005D9D56 /* NSNumber+JavaNumber.m */,
 				066193E4155849F80004DAFE /* NSObject+JavaObject.h */,
@@ -17473,6 +17478,7 @@
 				063BD982250597C0000819BB /* Ref.m in Sources */,
 				063BE77F2505E93F000819BB /* UnicodeSet.m in Sources */,
 				063BD983250597C0000819BB /* Reference.m in Sources */,
+				B19F4ED0262DD384003B9F32 /* NSEnumeratorToJavaUtilListIteratorAdapter.m in Sources */,
 				063BE6042505D716000819BB /* ICUResourceBundleImpl.m in Sources */,
 				063BE03E2505BE0B000819BB /* DecimalStyle.m in Sources */,
 				063BDEEF2505BD45000819BB /* Path.m in Sources */,

--- a/jre_emul/jre_sources.mk
+++ b/jre_emul/jre_sources.mk
@@ -70,7 +70,8 @@ NATIVE_JRE_SOURCES_CORE = \
   libcore_icu_ICU.m \
   libcore_io_Memory.m \
   objc-sync.m \
-  sun_misc_Unsafe.m
+  sun_misc_Unsafe.m \
+  NSArrayToJavaUtilListAdapter.m
 
 # Java sources to be translated normally and included in the core library.
 # TypeKind is needed by the Checker Framework (https://checkerframework.org/).
@@ -2407,7 +2408,8 @@ PUBLIC_NATIVE_HEADERS = \
   java/lang/reflect/Executable.h \
   java/lang/reflect/Field.h \
   java/lang/reflect/Method.h \
-  jni.h
+  jni.h \
+  NSArrayToJavaUtilListAdapter.h
 
 JRE_PUBLIC_PACKAGES = \
   java.awt.font \

--- a/jre_emul/jre_sources.mk
+++ b/jre_emul/jre_sources.mk
@@ -71,7 +71,8 @@ NATIVE_JRE_SOURCES_CORE = \
   libcore_io_Memory.m \
   objc-sync.m \
   sun_misc_Unsafe.m \
-  NSArrayToJavaUtilListAdapter.m
+  NSArrayToJavaUtilListAdapter.m \
+  NSEnumeratorToJavaUtilListIteratorAdapter.m
 
 # Java sources to be translated normally and included in the core library.
 # TypeKind is needed by the Checker Framework (https://checkerframework.org/).
@@ -2409,7 +2410,8 @@ PUBLIC_NATIVE_HEADERS = \
   java/lang/reflect/Field.h \
   java/lang/reflect/Method.h \
   jni.h \
-  NSArrayToJavaUtilListAdapter.h
+  NSArrayToJavaUtilListAdapter.h \
+  NSEnumeratorToJavaUtilListIteratorAdapter.h
 
 JRE_PUBLIC_PACKAGES = \
   java.awt.font \

--- a/kotlin-interop-test-cases/src/commonMain/kotlin/test/collections/KotlinLists.kt
+++ b/kotlin-interop-test-cases/src/commonMain/kotlin/test/collections/KotlinLists.kt
@@ -1,0 +1,6 @@
+package com.mirego.interop.kotlin.test.collections
+
+class KotlinLists() {
+    val list: List<String> = listOf("A", "B", "C", "D", "E")
+    val mutableList: MutableList<String> = mutableListOf("1", "2", "3", "4", "5")
+}

--- a/kotlin-native-tests/header-mapping.j2objc
+++ b/kotlin-native-tests/header-mapping.j2objc
@@ -6,3 +6,4 @@ com.mirego.interop.kotlin.test.objects=Common_wrapper.h
 com.mirego.interop.kotlin.test.nullsafety=Common_wrapper.h
 com.mirego.interop.kotlin.test.dataclass=Common_wrapper.h
 com.mirego.interop.kotlin.test.enums=Common_wrapper.h
+com.mirego.interop.kotlin.test.collections=Common_wrapper.h

--- a/kotlin-native-tests/src/test/java/CollectionsTests.java
+++ b/kotlin-native-tests/src/test/java/CollectionsTests.java
@@ -1,0 +1,20 @@
+import com.mirego.interop.java.test.collections.*;
+import junit.framework.TestCase;
+import org.junit.Test;
+
+public class CollectionsTests extends TestCase {
+
+    private static final String[] NO_ARGS = {""};
+
+    @Test
+    public void testLoopThroughtList() {
+        LoopThroughList loopThroughList = new LoopThroughList();
+        assertEquals("ABCDE", loopThroughList.main(NO_ARGS));
+    }
+
+    @Test
+    public void testLoopThroughtMutableList() {
+        LoopThroughMutableList loopThroughMutableList = new LoopThroughMutableList();
+        assertEquals("12345", loopThroughMutableList.main(NO_ARGS));
+    }
+}

--- a/kotlin-native-tests/src/test/java/NativeTestSuite.java
+++ b/kotlin-native-tests/src/test/java/NativeTestSuite.java
@@ -10,6 +10,7 @@ public class NativeTestSuite {
     private static final Class<?>[] nativeTests =
         new Class<?>[]{
                 ClassTests.class,
+                CollectionsTests.class,
                 ConstructorTests.class,
                 InterfacesTests.class,
                 FunctionTests.class,

--- a/translator/src/main/java/com/google/devtools/j2objc/gen/StatementGenerator.java
+++ b/translator/src/main/java/com/google/devtools/j2objc/gen/StatementGenerator.java
@@ -775,7 +775,7 @@ public class StatementGenerator extends UnitTreeVisitor {
 
       // MIREGO kotlin interop >>
       Expression expression = node.getExpression();
-      if (isKotlinExpression(expression)) {
+      if (KotlinUtil.isKotlinExpression(expression)) {
         convertCaseKotlin(expression);
       } else {
         expression.accept(this);
@@ -1034,15 +1034,6 @@ public class StatementGenerator extends UnitTreeVisitor {
     return false;
   }
 
-  private static Element getElementFromExpression(Expression expression) {
-    return expression != null ? TreeUtil.getVariableElement(expression) : null;
-  }
-
-  private static boolean isKotlinExpression(Expression expression) {
-    Element element = getElementFromExpression(expression);
-    return element != null && ElementUtil.isKotlinType(element);
-  }
-
   private static int findOrdinalForEnumValue(KmClass kotlinMetaData, String enumValue) {
     int ordinal = kotlinMetaData.getEnumEntries().indexOf(enumValue);
     if (ordinal == -1) {
@@ -1052,7 +1043,7 @@ public class StatementGenerator extends UnitTreeVisitor {
   }
 
   private void convertCaseKotlin(Expression expression) {
-    Element element = getElementFromExpression(expression);
+    Element element = KotlinUtil.getElementFromExpression(expression);
     KmClass kotlinMetaData = KotlinUtil.getKotlinMetaData(element);
 
     int flags = kotlinMetaData.getFlags();

--- a/translator/src/main/java/com/google/devtools/j2objc/gen/StatementGenerator.java
+++ b/translator/src/main/java/com/google/devtools/j2objc/gen/StatementGenerator.java
@@ -98,6 +98,7 @@ import com.google.devtools.j2objc.ast.VariableDeclarationFragment;
 import com.google.devtools.j2objc.ast.VariableDeclarationStatement;
 import com.google.devtools.j2objc.ast.WhileStatement;
 import com.google.devtools.j2objc.util.ElementUtil;
+import com.google.devtools.j2objc.util.KotlinUtil;
 import com.google.devtools.j2objc.util.NameTable;
 import com.google.devtools.j2objc.util.TypeUtil;
 import com.google.devtools.j2objc.util.UnicodeUtils;
@@ -1045,7 +1046,7 @@ public class StatementGenerator extends UnitTreeVisitor {
 
   private void convertCaseKotlin(Expression expression) {
     Element element = getElementFromExpression(expression);
-    KmClass kotlinMetaData = ElementUtil.getKotlinMetaData(element);
+    KmClass kotlinMetaData = KotlinUtil.getKotlinMetaData(element);
 
     int flags = kotlinMetaData.getFlags();
     if (Flag.Class.IS_ENUM_CLASS.invoke(flags)) {

--- a/translator/src/main/java/com/google/devtools/j2objc/pipeline/TranslationProcessor.java
+++ b/translator/src/main/java/com/google/devtools/j2objc/pipeline/TranslationProcessor.java
@@ -40,6 +40,7 @@ import com.google.devtools.j2objc.translate.InitializationNormalizer;
 import com.google.devtools.j2objc.translate.InnerClassExtractor;
 import com.google.devtools.j2objc.translate.JavaCloneWriter;
 import com.google.devtools.j2objc.translate.JavaToIOSMethodTranslator;
+import com.google.devtools.j2objc.translate.KotlinCollectionsConverter;
 import com.google.devtools.j2objc.translate.LabelRewriter;
 import com.google.devtools.j2objc.translate.LambdaRewriter;
 import com.google.devtools.j2objc.translate.LambdaTypeElementAdder;
@@ -186,6 +187,9 @@ public class TranslationProcessor extends FileProcessor {
 
     new ZeroingWeakRewriter(unit).run();
     ticker.tick("ZeroingWeakRewriter");
+
+    new KotlinCollectionsConverter(unit).run();
+    ticker.tick("KotlinCollectionsConverter");
 
     // Rewrite enhanced for loops into correct C code.
     new EnhancedForRewriter(unit).run();

--- a/translator/src/main/java/com/google/devtools/j2objc/translate/Functionizer.java
+++ b/translator/src/main/java/com/google/devtools/j2objc/translate/Functionizer.java
@@ -52,6 +52,7 @@ import com.google.devtools.j2objc.types.GeneratedExecutableElement;
 import com.google.devtools.j2objc.types.GeneratedVariableElement;
 import com.google.devtools.j2objc.util.CaptureInfo;
 import com.google.devtools.j2objc.util.ElementUtil;
+import com.google.devtools.j2objc.util.KotlinUtil;
 import com.google.devtools.j2objc.util.NameTable;
 import com.google.devtools.j2objc.util.TypeUtil;
 import com.google.devtools.j2objc.util.UnicodeUtils;
@@ -720,7 +721,7 @@ public class Functionizer extends UnitTreeVisitor {
       return;
     }
 
-    KmClass kmClass = ElementUtil.getKotlinMetaData(element);
+    KmClass kmClass = KotlinUtil.getKotlinMetaData(element);
 
     KmProperty getterOrSetterProperty = ElementUtil.getKotlinGetterOrSetter(element, kmClass);
     if (getterOrSetterProperty != null) {

--- a/translator/src/main/java/com/google/devtools/j2objc/translate/KotlinCollectionsConverter.java
+++ b/translator/src/main/java/com/google/devtools/j2objc/translate/KotlinCollectionsConverter.java
@@ -1,0 +1,95 @@
+package com.google.devtools.j2objc.translate;
+
+import com.google.devtools.j2objc.ast.Assignment;
+import com.google.devtools.j2objc.ast.CompilationUnit;
+import com.google.devtools.j2objc.ast.ExpressionStatement;
+import com.google.devtools.j2objc.ast.FunctionInvocation;
+import com.google.devtools.j2objc.ast.MethodInvocation;
+import com.google.devtools.j2objc.ast.UnitTreeVisitor;
+import com.google.devtools.j2objc.types.FunctionElement;
+import com.google.devtools.j2objc.util.ElementUtil;
+import com.google.devtools.j2objc.util.KotlinUtil;
+import com.google.devtools.j2objc.util.KotlinUtil.KotlinCollectionType;
+import com.google.devtools.j2objc.util.TypeUtil;
+
+import javax.lang.model.element.ExecutableElement;
+
+/**
+ * Adds support for convertin Collections comming for Kotlin Native Code
+ * to Java Collections to ensure compatibility
+ *
+ * @author Mirego 2021
+ */
+
+public class KotlinCollectionsConverter extends UnitTreeVisitor {
+
+    private static final FunctionElement TO_JAVA_LIST =
+            new FunctionElement("toJavaUtilList", TypeUtil.ID_TYPE, null)
+                    .addParameters(TypeUtil.ID_TYPE);
+
+    public KotlinCollectionsConverter(CompilationUnit unit) {
+        super(unit);
+    }
+
+    @Override
+    public boolean visit(Assignment node) {
+        return super.visit(node);
+    }
+
+    @Override
+    public void endVisit(Assignment node) {
+        super.endVisit(node);
+    }
+
+    @Override
+    public boolean visit(ExpressionStatement node) {
+        return super.visit(node);
+    }
+
+    @Override
+    public void endVisit(ExpressionStatement node) {
+        super.endVisit(node);
+    }
+
+    @Override
+    public boolean visit(MethodInvocation node) {
+        return super.visit(node);
+    }
+
+    @Override
+    public void endVisit(MethodInvocation node) {
+        ExecutableElement executableElement = node.getExecutableElement();
+        if (!ElementUtil.isKotlinType(executableElement)) {
+            return;
+        }
+
+        // we need to determine if we are returning a collection type that needs
+        // conversion
+
+        KotlinCollectionType kotlinReturnType = KotlinUtil.getKotlinReturnType(executableElement.getReturnType());
+        if (kotlinReturnType == KotlinCollectionType.NONE) {
+            return;
+        }
+
+        addTypeConversion(node, kotlinReturnType);
+    }
+
+    private void addTypeConversion(MethodInvocation node, KotlinCollectionType kotlinReturnType) {
+        FunctionElement functionElement = null;
+        switch (kotlinReturnType) {
+
+            case LIST:
+                functionElement = TO_JAVA_LIST;
+                break;
+            case NONE:
+            default:
+                return;
+        }
+
+        FunctionInvocation typeConversionInvocation =
+                new FunctionInvocation(functionElement, node.getTypeMirror());
+        node.replaceWith(typeConversionInvocation);
+        typeConversionInvocation.addArgument(node);
+    }
+
+}

--- a/translator/src/main/java/com/google/devtools/j2objc/translate/KotlinCollectionsConverter.java
+++ b/translator/src/main/java/com/google/devtools/j2objc/translate/KotlinCollectionsConverter.java
@@ -34,23 +34,6 @@ public class KotlinCollectionsConverter extends UnitTreeVisitor {
     }
 
     @Override
-    public boolean visit(Assignment node) {
-        return super.visit(node);
-    }
-
-    @Override
-    public void endVisit(Assignment node) {
-        super.endVisit(node);
-    }
-
-    @Override
-    public boolean visit(ExpressionStatement node) {
-        return super.visit(node);
-    }
-        super.endVisit(node);
-    }
-
-    @Override
     public void endVisit(MethodInvocation node) {
         ExecutableElement executableElement = node.getExecutableElement();
         if (ElementUtil.isKotlinType(executableElement)) {

--- a/translator/src/main/java/com/google/devtools/j2objc/translate/KotlinCollectionsConverter.java
+++ b/translator/src/main/java/com/google/devtools/j2objc/translate/KotlinCollectionsConverter.java
@@ -2,6 +2,8 @@ package com.google.devtools.j2objc.translate;
 
 import com.google.devtools.j2objc.ast.Assignment;
 import com.google.devtools.j2objc.ast.CompilationUnit;
+import com.google.devtools.j2objc.ast.EnhancedForStatement;
+import com.google.devtools.j2objc.ast.Expression;
 import com.google.devtools.j2objc.ast.ExpressionStatement;
 import com.google.devtools.j2objc.ast.FunctionInvocation;
 import com.google.devtools.j2objc.ast.MethodInvocation;
@@ -45,33 +47,20 @@ public class KotlinCollectionsConverter extends UnitTreeVisitor {
     public boolean visit(ExpressionStatement node) {
         return super.visit(node);
     }
-
-    @Override
-    public void endVisit(ExpressionStatement node) {
         super.endVisit(node);
-    }
-
-    @Override
-    public boolean visit(MethodInvocation node) {
-        return super.visit(node);
     }
 
     @Override
     public void endVisit(MethodInvocation node) {
         ExecutableElement executableElement = node.getExecutableElement();
-        if (!ElementUtil.isKotlinType(executableElement)) {
-            return;
+        if (ElementUtil.isKotlinType(executableElement)) {
+            KotlinCollectionType kotlinReturnType = KotlinUtil.getKotlinReturnType(executableElement.getReturnType());
+            if (kotlinReturnType != KotlinCollectionType.NONE) {
+                addTypeConversion(node, kotlinReturnType);
+                return;
+            }
         }
-
-        // we need to determine if we are returning a collection type that needs
-        // conversion
-
-        KotlinCollectionType kotlinReturnType = KotlinUtil.getKotlinReturnType(executableElement.getReturnType());
-        if (kotlinReturnType == KotlinCollectionType.NONE) {
-            return;
-        }
-
-        addTypeConversion(node, kotlinReturnType);
+        super.endVisit(node);
     }
 
     private void addTypeConversion(MethodInvocation node, KotlinCollectionType kotlinReturnType) {

--- a/translator/src/main/java/com/google/devtools/j2objc/util/ElementUtil.java
+++ b/translator/src/main/java/com/google/devtools/j2objc/util/ElementUtil.java
@@ -30,6 +30,7 @@ import com.google.j2objc.annotations.RetainedWith;
 import com.sun.tools.javac.code.Flags;
 import com.sun.tools.javac.code.Symbol;
 import com.sun.tools.javac.code.Symbol.ClassSymbol;
+
 import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.Collections;
@@ -42,6 +43,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.regex.Pattern;
+
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 import javax.lang.model.AnnotatedConstruct;
@@ -61,14 +63,11 @@ import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
 import javax.lang.model.util.Elements;
 import javax.tools.JavaFileObject;
-import kotlin.Metadata;
+
 import kotlinx.metadata.Flag;
-import kotlinx.metadata.Flag.Common;
 import kotlinx.metadata.KmClass;
 import kotlinx.metadata.KmFunction;
 import kotlinx.metadata.KmProperty;
-import kotlinx.metadata.jvm.KotlinClassHeader;
-import kotlinx.metadata.jvm.KotlinClassMetadata;
 
 /**
  * Utility methods for working with elements.
@@ -961,13 +960,6 @@ public final class ElementUtil {
       }
     }
     return null;
-  }
-
-  public static KmClass getKotlinMetaData(Element element) {
-    Metadata meta = element.getEnclosingElement().getAnnotation(Metadata.class);
-    KotlinClassHeader header = new KotlinClassHeader(meta.k(), meta.mv(), meta.bv(), meta.d1(), meta.d2(), meta.xs(), meta.pn(), meta.xi());
-    KotlinClassMetadata metadata = KotlinClassMetadata.read(header);
-    return ((KotlinClassMetadata.Class) metadata).toKmClass();
   }
 
   // MIREGO <<

--- a/translator/src/main/java/com/google/devtools/j2objc/util/KotlinUtil.java
+++ b/translator/src/main/java/com/google/devtools/j2objc/util/KotlinUtil.java
@@ -1,5 +1,12 @@
 package com.google.devtools.j2objc.util;
 
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.ListIterator;
+
 import javax.lang.model.element.Element;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.TypeElement;
@@ -42,5 +49,130 @@ public final class KotlinUtil {
         KotlinClassHeader header = new KotlinClassHeader(meta.k(), meta.mv(), meta.bv(), meta.d1(), meta.d2(), meta.xs(), meta.pn(), meta.xi());
         KotlinClassMetadata metadata = KotlinClassMetadata.read(header);
         return ((KotlinClassMetadata.Class) metadata).toKmClass();
+    }
+}
+
+
+class KotlinTestList implements List {
+
+    @Override
+    public int size() {
+        return 0;
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return false;
+    }
+
+    @Override
+    public boolean contains(Object o) {
+        return false;
+    }
+
+    @NotNull
+    @Override
+    public Iterator iterator() {
+        return null;
+    }
+
+    @NotNull
+    @Override
+    public Object[] toArray() {
+        return new Object[0];
+    }
+
+    @Override
+    public boolean add(Object o) {
+        return false;
+    }
+
+    @Override
+    public boolean remove(Object o) {
+        return false;
+    }
+
+    @Override
+    public boolean addAll(@NotNull Collection collection) {
+        return false;
+    }
+
+    @Override
+    public boolean addAll(int i, @NotNull Collection collection) {
+        return false;
+    }
+
+    @Override
+    public void clear() {
+
+    }
+
+    @Override
+    public Object get(int i) {
+        return null;
+    }
+
+    @Override
+    public Object set(int i, Object o) {
+        return null;
+    }
+
+    @Override
+    public void add(int i, Object o) {
+
+    }
+
+    @Override
+    public Object remove(int i) {
+        return null;
+    }
+
+    @Override
+    public int indexOf(Object o) {
+        return 0;
+    }
+
+    @Override
+    public int lastIndexOf(Object o) {
+        return 0;
+    }
+
+    @NotNull
+    @Override
+    public ListIterator listIterator() {
+        return null;
+    }
+
+    @NotNull
+    @Override
+    public ListIterator listIterator(int i) {
+        return null;
+    }
+
+    @NotNull
+    @Override
+    public List subList(int i, int i1) {
+        return null;
+    }
+
+    @Override
+    public boolean retainAll(@NotNull Collection collection) {
+        return false;
+    }
+
+    @Override
+    public boolean removeAll(@NotNull Collection collection) {
+        return false;
+    }
+
+    @Override
+    public boolean containsAll(@NotNull Collection collection) {
+        return false;
+    }
+
+    @NotNull
+    @Override
+    public Object[] toArray(@NotNull Object[] objects) {
+        return new Object[0];
     }
 }

--- a/translator/src/main/java/com/google/devtools/j2objc/util/KotlinUtil.java
+++ b/translator/src/main/java/com/google/devtools/j2objc/util/KotlinUtil.java
@@ -15,9 +15,13 @@ import kotlinx.metadata.jvm.KotlinClassMetadata;
 
 public final class KotlinUtil {
 
+    private KotlinUtil() {
+        // DISABLED
+    }
+
     public enum KotlinCollectionType {
-        LIST,
         NONE,
+        LIST,
     }
 
     public static KotlinCollectionType getKotlinReturnType(TypeMirror type) {

--- a/translator/src/main/java/com/google/devtools/j2objc/util/KotlinUtil.java
+++ b/translator/src/main/java/com/google/devtools/j2objc/util/KotlinUtil.java
@@ -1,0 +1,46 @@
+package com.google.devtools.j2objc.util;
+
+import javax.lang.model.element.Element;
+import javax.lang.model.element.ExecutableElement;
+import javax.lang.model.element.TypeElement;
+import javax.lang.model.type.TypeKind;
+import javax.lang.model.type.TypeMirror;
+
+import kotlin.Metadata;
+import kotlinx.metadata.KmClass;
+import kotlinx.metadata.jvm.KotlinClassHeader;
+import kotlinx.metadata.jvm.KotlinClassMetadata;
+
+public final class KotlinUtil {
+
+    public enum KotlinCollectionType {
+        LIST,
+        NONE,
+    }
+
+    public static KotlinCollectionType getKotlinReturnType(TypeMirror type) {
+        TypeElement typeElement = TypeUtil.asTypeElement(type);
+        if (typeElement != null) {
+            if (typeElement.getQualifiedName().contentEquals("java.util.List")) {
+                return KotlinCollectionType.LIST;
+            }
+        }
+
+        return KotlinCollectionType.NONE;
+    }
+
+    private static boolean isJavaCollectionType(TypeMirror returnType) {
+        if (returnType.getKind() == TypeKind.ARRAY) {
+            return true;
+        }
+
+        return false;
+    }
+
+    public static KmClass getKotlinMetaData(Element element) {
+        Metadata meta = element.getEnclosingElement().getAnnotation(Metadata.class);
+        KotlinClassHeader header = new KotlinClassHeader(meta.k(), meta.mv(), meta.bv(), meta.d1(), meta.d2(), meta.xs(), meta.pn(), meta.xi());
+        KotlinClassMetadata metadata = KotlinClassMetadata.read(header);
+        return ((KotlinClassMetadata.Class) metadata).toKmClass();
+    }
+}

--- a/translator/src/main/java/com/google/devtools/j2objc/util/KotlinUtil.java
+++ b/translator/src/main/java/com/google/devtools/j2objc/util/KotlinUtil.java
@@ -1,16 +1,11 @@
 package com.google.devtools.j2objc.util;
 
-import org.jetbrains.annotations.NotNull;
-
-import java.util.Collection;
-import java.util.Iterator;
-import java.util.List;
-import java.util.ListIterator;
+import com.google.devtools.j2objc.ast.Expression;
+import com.google.devtools.j2objc.ast.MethodInvocation;
+import com.google.devtools.j2objc.ast.TreeUtil;
 
 import javax.lang.model.element.Element;
-import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.TypeElement;
-import javax.lang.model.type.TypeKind;
 import javax.lang.model.type.TypeMirror;
 
 import kotlin.Metadata;
@@ -36,143 +31,36 @@ public final class KotlinUtil {
         return KotlinCollectionType.NONE;
     }
 
-    private static boolean isJavaCollectionType(TypeMirror returnType) {
-        if (returnType.getKind() == TypeKind.ARRAY) {
-            return true;
-        }
-
-        return false;
-    }
-
     public static KmClass getKotlinMetaData(Element element) {
         Metadata meta = element.getEnclosingElement().getAnnotation(Metadata.class);
         KotlinClassHeader header = new KotlinClassHeader(meta.k(), meta.mv(), meta.bv(), meta.d1(), meta.d2(), meta.xs(), meta.pn(), meta.xi());
         KotlinClassMetadata metadata = KotlinClassMetadata.read(header);
         return ((KotlinClassMetadata.Class) metadata).toKmClass();
     }
-}
 
+    public static Element getElementFromExpression(Expression expression) {
+        if (expression == null) {
+            return null;
+        }
 
-class KotlinTestList implements List {
-
-    @Override
-    public int size() {
-        return 0;
+        Element element = TreeUtil.getVariableElement(expression);
+        if (element == null) {
+            element = TreeUtil.getExecutableElement(expression);
+        }
+        return element;
     }
 
-    @Override
-    public boolean isEmpty() {
-        return false;
+    public static boolean isKotlinExpression(Expression expression) {
+        Element element = getElementFromExpression(expression);
+        return element != null && ElementUtil.isKotlinType(element);
     }
 
-    @Override
-    public boolean contains(Object o) {
-        return false;
-    }
+    public static KotlinCollectionType getExpressionKotlinReturnType(Expression expression) {
+        if (expression instanceof MethodInvocation) {
+            MethodInvocation methodInvocation = (MethodInvocation) expression;
+            return getKotlinReturnType(methodInvocation.getExecutablePair().element().getReturnType());
+        }
 
-    @NotNull
-    @Override
-    public Iterator iterator() {
-        return null;
-    }
-
-    @NotNull
-    @Override
-    public Object[] toArray() {
-        return new Object[0];
-    }
-
-    @Override
-    public boolean add(Object o) {
-        return false;
-    }
-
-    @Override
-    public boolean remove(Object o) {
-        return false;
-    }
-
-    @Override
-    public boolean addAll(@NotNull Collection collection) {
-        return false;
-    }
-
-    @Override
-    public boolean addAll(int i, @NotNull Collection collection) {
-        return false;
-    }
-
-    @Override
-    public void clear() {
-
-    }
-
-    @Override
-    public Object get(int i) {
-        return null;
-    }
-
-    @Override
-    public Object set(int i, Object o) {
-        return null;
-    }
-
-    @Override
-    public void add(int i, Object o) {
-
-    }
-
-    @Override
-    public Object remove(int i) {
-        return null;
-    }
-
-    @Override
-    public int indexOf(Object o) {
-        return 0;
-    }
-
-    @Override
-    public int lastIndexOf(Object o) {
-        return 0;
-    }
-
-    @NotNull
-    @Override
-    public ListIterator listIterator() {
-        return null;
-    }
-
-    @NotNull
-    @Override
-    public ListIterator listIterator(int i) {
-        return null;
-    }
-
-    @NotNull
-    @Override
-    public List subList(int i, int i1) {
-        return null;
-    }
-
-    @Override
-    public boolean retainAll(@NotNull Collection collection) {
-        return false;
-    }
-
-    @Override
-    public boolean removeAll(@NotNull Collection collection) {
-        return false;
-    }
-
-    @Override
-    public boolean containsAll(@NotNull Collection collection) {
-        return false;
-    }
-
-    @NotNull
-    @Override
-    public Object[] toArray(@NotNull Object[] objects) {
-        return new Object[0];
+        return KotlinCollectionType.NONE;
     }
 }

--- a/translator/src/main/java/com/google/devtools/j2objc/util/NameTable.java
+++ b/translator/src/main/java/com/google/devtools/j2objc/util/NameTable.java
@@ -791,7 +791,7 @@ public class NameTable {
                                      StringBuilder sb,
                                      TypeElement declaringClass) {
 
-    KmClass kmClass = ElementUtil.getKotlinMetaData(method);
+    KmClass kmClass = KotlinUtil.getKotlinMetaData(method);
     List<KmTypeParameter> kmClassTypeParameters = kmClass.getTypeParameters();
 
     String methodName = method.getSimpleName().toString();

--- a/translator/src/test/java/com/google/devtools/j2objc/kotlin/CollectionsTest.java
+++ b/translator/src/test/java/com/google/devtools/j2objc/kotlin/CollectionsTest.java
@@ -1,0 +1,32 @@
+package com.google.devtools.j2objc.kotlin;
+
+import com.google.devtools.j2objc.GenerationTest;
+import com.mirego.interop.java.test.collections.LoopThroughList;
+import com.mirego.interop.java.test.collections.LoopThroughMutableList;
+
+import org.junit.Test;
+
+import java.io.IOException;
+
+public class CollectionsTest extends GenerationTest {
+
+    final private static String testPackage = "collections/";
+
+    @Test
+    public void testLoopThroughtList() throws IOException {
+
+        String className = LoopThroughList.class.getSimpleName();
+        String translation = translateJavaSourceFileForKotlinTest(className, testPackage, ".m");
+
+        assertTranslation(translation, "id<JavaUtilList> list = toJavaUtilList(kotlinLists.list);");
+    }
+
+    @Test
+    public void testLoopThroughtMutableList() throws IOException {
+
+        String className = LoopThroughMutableList.class.getSimpleName();
+        String translation = translateJavaSourceFileForKotlinTest(className, testPackage, ".m");
+
+        assertTranslation(translation, "id<JavaUtilList> list = toJavaUtilList(kotlinLists.mutableList);");
+    }
+}

--- a/translator/src/test/java/com/mirego/interop/java/test/collections/LoopThroughList.java
+++ b/translator/src/test/java/com/mirego/interop/java/test/collections/LoopThroughList.java
@@ -12,7 +12,7 @@ public class LoopThroughList {
 
         List<String> list = kotlinLists.getList();
         String output = "";
-        for(String element: list) {
+        for (String element : list) {
             output += element;
         }
         return output;

--- a/translator/src/test/java/com/mirego/interop/java/test/collections/LoopThroughList.java
+++ b/translator/src/test/java/com/mirego/interop/java/test/collections/LoopThroughList.java
@@ -1,0 +1,20 @@
+package com.mirego.interop.java.test.collections;
+
+import com.mirego.interop.kotlin.test.collections.KotlinLists;
+
+import java.util.List;
+
+public class LoopThroughList {
+
+    public static String main(String[] args) {
+
+        KotlinLists kotlinLists = new KotlinLists();
+
+        List<String> list = kotlinLists.getList();
+        String output = "";
+        for(String element: list) {
+            output += element;
+        }
+        return output;
+    }
+}

--- a/translator/src/test/java/com/mirego/interop/java/test/collections/LoopThroughMutableList.java
+++ b/translator/src/test/java/com/mirego/interop/java/test/collections/LoopThroughMutableList.java
@@ -1,0 +1,20 @@
+package com.mirego.interop.java.test.collections;
+
+import com.mirego.interop.kotlin.test.collections.KotlinLists;
+
+import java.util.List;
+
+public class LoopThroughMutableList {
+
+    public static String main(String[] args) {
+
+        KotlinLists kotlinLists = new KotlinLists();
+
+        List<String> list = kotlinLists.getMutableList();
+        String output = "";
+        for(String element: list) {
+            output += element;
+        }
+        return output;
+    }
+}

--- a/translator/src/test/java/com/mirego/interop/java/test/collections/LoopThroughMutableList.java
+++ b/translator/src/test/java/com/mirego/interop/java/test/collections/LoopThroughMutableList.java
@@ -12,7 +12,7 @@ public class LoopThroughMutableList {
 
         List<String> list = kotlinLists.getMutableList();
         String output = "";
-        for(String element: list) {
+        for (String element : list) {
             output += element;
         }
         return output;


### PR DESCRIPTION
Some methods in kotlin return NSArray for example when accessing a Kotlin List. This is the addition of NSArrayToJavaUtilListAdapter to J2ObjC jre_emul. So we can use them as javaUtilList. This also contains and adapter for the Iterator.

At this moment we only support unmodifiableList so all type of list will crash if you try to modify them.