### PR TITLE
Mirego/kinternship/companion

### DIFF
--- a/java_deps/pom.xml
+++ b/java_deps/pom.xml
@@ -259,5 +259,10 @@
       <artifactId>kotlin-stdlib</artifactId>
       <version>1.4.21</version>
     </dependency>
+    <dependency>
+      <groupId>org.jetbrains</groupId>
+      <artifactId>annotations</artifactId>
+      <version>20.1.0</version>
+    </dependency>
   </dependencies>
 </project>

--- a/translator/src/main/java/com/google/devtools/j2objc/translate/Functionizer.java
+++ b/translator/src/main/java/com/google/devtools/j2objc/translate/Functionizer.java
@@ -51,6 +51,7 @@ import com.google.devtools.j2objc.types.GeneratedExecutableElement;
 import com.google.devtools.j2objc.types.GeneratedVariableElement;
 import com.google.devtools.j2objc.util.CaptureInfo;
 import com.google.devtools.j2objc.util.ElementUtil;
+import com.google.devtools.j2objc.util.KotlinMetadataUtil;
 import com.google.devtools.j2objc.util.NameTable;
 import com.google.devtools.j2objc.util.TypeUtil;
 import com.google.devtools.j2objc.util.UnicodeUtils;
@@ -274,6 +275,9 @@ public class Functionizer extends UnitTreeVisitor {
     if (ElementUtil.isStatic(method)) {
       String commonClassName = fullName.substring(0, fullName.indexOf("_"));
       Name className =  ElementUtil.getDeclaringClass(method).getSimpleName();
+      if(KotlinMetadataUtil.isCompanionMethod(method)) {
+        commonClassName += className.toString();
+      }
 
       GeneratedExecutableElement commonClassElement = GeneratedExecutableElement
           .newMethodWithSelector(commonClassName, node.getExecutableType(), ElementUtil.getDeclaringClass(method));

--- a/translator/src/main/java/com/google/devtools/j2objc/util/ElementUtil.java
+++ b/translator/src/main/java/com/google/devtools/j2objc/util/ElementUtil.java
@@ -111,7 +111,11 @@ public final class ElementUtil {
   }
 
   public static boolean isStatic(Element element) {
-    return hasModifier(element, Modifier.STATIC);
+    boolean isCompanion = false;
+    if(isKotlinType(element) && isExecutableElement(element)) {
+      isCompanion = KotlinMetadataUtil.isCompanionMethod(element);
+    }
+    return hasModifier(element, Modifier.STATIC) || isCompanion;
   }
 
   public static boolean isDefault(Element element) {
@@ -342,6 +346,7 @@ public final class ElementUtil {
   }
 
   private static boolean hasModifier(Element element, Modifier modifier) {
+    Set<Modifier> modifiers = element.getModifiers();
     return element.getModifiers().contains(modifier);
   }
 

--- a/translator/src/main/java/com/google/devtools/j2objc/util/ElementUtil.java
+++ b/translator/src/main/java/com/google/devtools/j2objc/util/ElementUtil.java
@@ -346,7 +346,6 @@ public final class ElementUtil {
   }
 
   private static boolean hasModifier(Element element, Modifier modifier) {
-    Set<Modifier> modifiers = element.getModifiers();
     return element.getModifiers().contains(modifier);
   }
 

--- a/translator/src/main/java/com/google/devtools/j2objc/util/KotlinMetadataUtil.java
+++ b/translator/src/main/java/com/google/devtools/j2objc/util/KotlinMetadataUtil.java
@@ -7,6 +7,7 @@ import javax.lang.model.element.Element;
 import javax.lang.model.element.ExecutableElement;
 
 import kotlin.Metadata;
+import kotlinx.metadata.Flag;
 import kotlinx.metadata.KmClass;
 import kotlinx.metadata.KmConstructor;
 import kotlinx.metadata.KmFunction;
@@ -52,6 +53,11 @@ public class KotlinMetadataUtil {
     return kmClass;
   }
 
+  public static boolean isCompanionMethod(Element element) {
+    Element enclosingElement = element.getEnclosingElement();
+    KmClass kmClass = getClass(enclosingElement);
+    return Flag.Class.IS_COMPANION_OBJECT.invoke(kmClass.getFlags());
+  }
   private static List<KmValueParameter> findMatchingFunction(KmClass kotlinClass, String functionName) {
     List<KmValueParameter> parameters = new ArrayList<>();
 

--- a/translator/src/test/java/com/google/devtools/j2objc/GenerationTest.java
+++ b/translator/src/test/java/com/google/devtools/j2objc/GenerationTest.java
@@ -121,15 +121,18 @@ public class GenerationTest extends TestCase {
   protected void loadOptions() throws IOException {
     options = new Options();
     String tempPath = tempDir.getAbsolutePath();
-    String jarRelativePath = "../common/build/libs/common-jvm-0.0.1.jar";
-    String jarAbsolutePath = FileSystems.getDefault().getPath(jarRelativePath).normalize().toAbsolutePath().toString();
-    jarAbsolutePath = jarAbsolutePath.replace("submodules/j2objc/translator/../", "");
+    String kotlinJarRelativePath = "../common/build/libs/common-jvm-0.0.1.jar";
+    String annotationJarRelativePath = "../java_deps/build_result/annotations-20.1.0.jar";
+    String annotationJarAbsolutePath = FileSystems.getDefault().getPath(annotationJarRelativePath).normalize().toAbsolutePath().toString();
+    String kotlinJarAbsolutePath = FileSystems.getDefault().getPath(kotlinJarRelativePath).normalize().toAbsolutePath().toString();
+    annotationJarAbsolutePath = annotationJarAbsolutePath.replace("translator/../", "");
+    kotlinJarAbsolutePath = kotlinJarAbsolutePath.replace("submodules/j2objc/translator/../", "");
     options.getPackagePrefixes().addPrefix("com.mirego.interop.*", "Common");
 
     options.load(new String[]{
         "-d", tempPath,
         "-sourcepath", tempPath,
-        "-classpath", tempPath + ":" + jarAbsolutePath,
+        "-classpath", tempPath + ":" + kotlinJarAbsolutePath + ":" + annotationJarAbsolutePath,
         "-q", // Suppress console output.
         "-encoding", "UTF-8" // Translate strings correctly when encodings are nonstandard.
     });

--- a/translator/src/test/java/com/google/devtools/j2objc/translate/FunctionizerTest.java
+++ b/translator/src/test/java/com/google/devtools/j2objc/translate/FunctionizerTest.java
@@ -16,29 +16,11 @@ package com.google.devtools.j2objc.translate;
 
 import com.google.devtools.j2objc.GenerationTest;
 import com.google.devtools.j2objc.Options.MemoryManagementOption;
-import com.google.devtools.j2objc.util.ElementUtil;
-import org.mockito.MockedStatic;
-import org.mockito.invocation.InvocationOnMock;
-import org.mockito.stubbing.Answer;
+
+import junit.framework.Test;
 
 import java.io.IOException;
 
-import javax.lang.model.element.Element;
-import javax.lang.model.element.ExecutableElement;
-import javax.lang.model.element.TypeElement;
-
-import kotlin.jvm.JvmStatic;
-import scenelib.annotations.el.ATypeElement;
-
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyBoolean;
-import static org.mockito.ArgumentMatchers.isA;
-import static org.mockito.ArgumentMatchers.notNull;
-import static org.mockito.Mockito.CALLS_REAL_METHODS;
-import static org.mockito.Mockito.RETURNS_DEFAULTS;
-import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.mockStatic;
 
 /**
  * Tests for {@link Functionizer}.
@@ -684,5 +666,33 @@ public class FunctionizerTest extends GenerationTest {
                     "}",
             "Test", "Test.m");
     assertTranslation(translation, "__unused NSString *value4 = [[CommonKotlinObject kotlinObject] staticMethodWithAnnotationMultipleParamsStringParam:@\"param\" numParam:1 intParam:1 boolParam:true];");
+  }
+
+  public void testKotlinCompanionWithNoName() throws IOException {
+    String translation = translateSourceFile(
+            "import com.mirego.interop.ConcreteClassWithConstructor;\n" +
+                    "@SuppressWarnings(\"unused\")\n" +
+                    "class Test {\n" +
+                    "public static void testCompanion() {\n" +
+                    "\n" +
+                    "        final String companionValue3 = ConcreteClassWithConstructor.Companion.unnamedCompanionMethod();\n" +
+                    "}\n" +
+                    "}",
+            "Test", "Test.m");
+    assertTranslation(translation, "__unused NSString *companionValue3 = [[CommonConcreteClassWithConstructorCompanion companion] unnamedCompanionMethod];");
+  }
+
+  public void testKotlinCompanionWithName() throws IOException {
+    String translation = translateSourceFile(
+            "import com.mirego.interop.ConcreteClassWithoutConstructor;\n" +
+                    "@SuppressWarnings(\"unused\")\n" +
+                    "class Test {\n" +
+                    "public static void testCompanion() {\n" +
+                    "\n" +
+                    "        final String companionValue2 = ConcreteClassWithoutConstructor.KotlinCompanion.companionMethod();\n" +
+                    "}\n" +
+                    "}",
+            "Test", "Test.m");
+    assertTranslation(translation, "__unused NSString *companionValue2 = [[CommonConcreteClassWithoutConstructorKotlinCompanion kotlinCompanion] companionMethod];");
   }
 }


### PR DESCRIPTION
## Description and motivation
Ajout d'une dépendance pour les tests permettant d'y utiliser des companion objects. Modification du functionnizer et de la méthode isStatic de ElementUtil pour transpiler correctement le code java qui appelle des méthodes de companion object. Ajout de tests pour les companions objects.
## Work done
### Tasks
- [x] Faire fonctionner les tests avec les companion objects
- [x] Transpilation de code qui utilise des companion objects
### Additional notes
L'utilisation des getter/setters des companion objects ne sont pas fonctionnels ici. Les getters/setters sont le sujet d'une autre issue en cours.
## Result
Les tests fonctionnent avec des calls aux companions objects et la transpilation donne le bon code transpilé.