### PR TITLE
Fixed translation of kotlin enums + added tests

### DIFF
--- a/translator/src/main/java/com/google/devtools/j2objc/translate/StaticVarRewriter.java
+++ b/translator/src/main/java/com/google/devtools/j2objc/translate/StaticVarRewriter.java
@@ -61,17 +61,28 @@ public class StaticVarRewriter extends UnitTreeVisitor {
     TypeElement declaringClass = ElementUtil.getDeclaringClass(var);
     boolean assignable = TranslationUtil.isAssigned(node);
     StringBuilder code = new StringBuilder(
+        ElementUtil.isKotlinType(var) ? "" :
         ElementUtil.isEnumConstant(var) ? "JreLoadEnum" : "JreLoadStatic");
     TypeMirror exprType = var.asType();
     if (assignable) {
       code.append("Ref");
       exprType = new PointerType(exprType);
     }
-    code.append("(");
-    code.append(nameTable.getFullName(declaringClass));
-    code.append(", ");
-    code.append(nameTable.getVariableShortName(var));
-    code.append(")");
+    
+    if (ElementUtil.isKotlinType(var)) {
+      code.append("[");
+      code.append(nameTable.getFullName(declaringClass));
+      code.append(" ");
+      code.append(nameTable.getVariableShortName(var).toLowerCase());
+      code.append("]");
+    } else {
+      code.append("(");
+      code.append(nameTable.getFullName(declaringClass));
+      code.append(", ");
+      code.append(nameTable.getVariableShortName(var));
+      code.append(")");
+    }
+    
     NativeExpression nativeExpr = new NativeExpression(code.toString(), exprType);
     nativeExpr.addImportType(declaringClass.asType());
     Expression newNode = nativeExpr;

--- a/translator/src/main/java/com/google/devtools/j2objc/translate/StaticVarRewriter.java
+++ b/translator/src/main/java/com/google/devtools/j2objc/translate/StaticVarRewriter.java
@@ -60,8 +60,9 @@ public class StaticVarRewriter extends UnitTreeVisitor {
 
     TypeElement declaringClass = ElementUtil.getDeclaringClass(var);
     boolean assignable = TranslationUtil.isAssigned(node);
+    boolean isKotlinType = ElementUtil.isKotlinType(var);
     StringBuilder code = new StringBuilder(
-        ElementUtil.isKotlinType(var) ? "" :
+        isKotlinType ? "" :
         ElementUtil.isEnumConstant(var) ? "JreLoadEnum" : "JreLoadStatic");
     TypeMirror exprType = var.asType();
     if (assignable) {
@@ -69,7 +70,7 @@ public class StaticVarRewriter extends UnitTreeVisitor {
       exprType = new PointerType(exprType);
     }
     
-    if (ElementUtil.isKotlinType(var)) {
+    if (isKotlinType) {
       code.append("[");
       code.append(nameTable.getFullName(declaringClass));
       code.append(" ");

--- a/translator/src/test/java/com/google/devtools/j2objc/translate/FunctionizerTest.java
+++ b/translator/src/test/java/com/google/devtools/j2objc/translate/FunctionizerTest.java
@@ -743,21 +743,6 @@ public class FunctionizerTest extends GenerationTest {
     assertTranslation(translation, "__unused CommonConcreteClassWithConstructor *concreteClassWithConstructor = [[CommonConcreteClassWithConstructor alloc] initWithIntParam:5];");
   }
 
-  public void testStaticMethodWithParams() throws IOException {
-    String translation = translateSourceFile(
-        "import com.mirego.interop.KotlinObject;\n" +
-            "@SuppressWarnings(\"unused\")\n" +
-            "class Test {\n" +
-            "public static void testStatic() {\n" +
-            "\n" +
-            "        final String value4 = KotlinObject.staticMethodWithAnnotationMultipleParams(\"param\", 1, 1, true);\n" +
-            "}\n" +
-            "}",
-        "Test", "Test.m");
-
-    assertTranslation(translation, "__unused NSString *value4 = [[CommonKotlinObject kotlinObject] staticMethodWithAnnotationMultipleParamsStringParam:@\"param\" numParam:1 intParam:1 boolParam:true];");
-  }
-
   public void testEnum() throws IOException {
     String translation = translateSourceFile(
         "import com.mirego.interop.KotlinEnum;\n" +

--- a/translator/src/test/java/com/google/devtools/j2objc/translate/FunctionizerTest.java
+++ b/translator/src/test/java/com/google/devtools/j2objc/translate/FunctionizerTest.java
@@ -695,4 +695,81 @@ public class FunctionizerTest extends GenerationTest {
             "Test", "Test.m");
     assertTranslation(translation, "__unused NSString *companionValue2 = [[CommonConcreteClassWithoutConstructorKotlinCompanion kotlinCompanion] companionMethod];");
   }
+
+  public void testInstanceMethodWithParams() throws IOException {
+    String translation = translateSourceFile(
+        "import com.mirego.interop.ConcreteClassWithoutConstructor;\n" +
+            "@SuppressWarnings(\"unused\")\n" +
+            "class Test {\n" +
+            "public static void testMethod() {\n" +
+            "\n" +
+            "        final ConcreteClassWithoutConstructor concreteClassWithoutConstructor = new ConcreteClassWithoutConstructor();\n" +
+            "        concreteClassWithoutConstructor.methodNativeParameters(5, false, 0.5);\n" +
+            "}\n" +
+            "}",
+        "Test", "Test.m");
+
+    assertTranslation(translation, "[concreteClassWithoutConstructor methodNativeParametersIntParam:5 boolParam:false doubleParam:0.5];");
+  }
+
+  public void testInstanceMethodNoParams() throws IOException {
+    String translation = translateSourceFile(
+        "import com.mirego.interop.ConcreteClassWithoutConstructor;\n" +
+            "@SuppressWarnings(\"unused\")\n" +
+            "class Test {\n" +
+            "public static void testMethod() {\n" +
+            "\n" +
+            "        final ConcreteClassWithoutConstructor concreteClassWithoutConstructor = new ConcreteClassWithoutConstructor();\n" +
+            "        final String returnValue = concreteClassWithoutConstructor.methodReturnValue();\n" +
+            "}\n" +
+            "}",
+        "Test", "Test.m");
+
+    assertTranslation(translation, "__unused NSString *returnValue = [concreteClassWithoutConstructor methodReturnValue];");
+  }
+
+  public void testConstructorNativeParams() throws IOException {
+    String translation = translateSourceFile(
+        "import com.mirego.interop.ConcreteClassWithConstructor;\n" +
+            "@SuppressWarnings(\"unused\")\n" +
+            "class Test {\n" +
+            "public static void testConstructor() {\n" +
+            "\n" +
+            "        final ConcreteClassWithConstructor concreteClassWithConstructor = new ConcreteClassWithConstructor(5);\n" +
+            "}\n" +
+            "}",
+        "Test", "Test.m");
+
+    assertTranslation(translation, "__unused CommonConcreteClassWithConstructor *concreteClassWithConstructor = [[CommonConcreteClassWithConstructor alloc] initWithIntParam:5];");
+  }
+
+  public void testStaticMethodWithParams() throws IOException {
+    String translation = translateSourceFile(
+        "import com.mirego.interop.KotlinObject;\n" +
+            "@SuppressWarnings(\"unused\")\n" +
+            "class Test {\n" +
+            "public static void testStatic() {\n" +
+            "\n" +
+            "        final String value4 = KotlinObject.staticMethodWithAnnotationMultipleParams(\"param\", 1, 1, true);\n" +
+            "}\n" +
+            "}",
+        "Test", "Test.m");
+
+    assertTranslation(translation, "__unused NSString *value4 = [[CommonKotlinObject kotlinObject] staticMethodWithAnnotationMultipleParamsStringParam:@\"param\" numParam:1 intParam:1 boolParam:true];");
+  }
+
+  public void testEnum() throws IOException {
+    String translation = translateSourceFile(
+        "import com.mirego.interop.KotlinEnum;\n" +
+            "@SuppressWarnings(\"unused\")\n" +
+            "class Test {\n" +
+            "public static void testEnum() {\n" +
+            "\n" +
+            "        final KotlinEnum enumValue = KotlinEnum.VALUE1;\n" +
+            "}\n" +
+            "}",
+        "Test", "Test.m");
+
+    assertTranslation(translation, "__unused CommonKotlinEnum *enumValue = [CommonKotlinEnum value1];");
+  }
 }


### PR DESCRIPTION
## Description and motivation
- Added support for kotlin enums in j2objc
## Work done
- Changed rewriting of static variable access to support enums of kotlin type
- Added unit tests in FunctionizerTests for enums and previous functionalities i.e. static methods with params, constructor with params and instance methods
### Tasks
- [x] fix kotlin enums
- [x] Unit tests
## Result
final KotlinEnum enumValue = KotlinEnum.VALUE1; -> __unused CommonKotlinEnum *enumValue = [CommonKotlinEnum value1];