### PR TITLE
mirego/kinternship/2.7-properties

### DIFF
--- a/translator/src/test/java/com/google/devtools/j2objc/translate/FunctionizerTest.java
+++ b/translator/src/test/java/com/google/devtools/j2objc/translate/FunctionizerTest.java
@@ -757,4 +757,34 @@ public class FunctionizerTest extends GenerationTest {
 
     assertTranslation(translation, "__unused CommonKotlinEnum *enumValue = [CommonKotlinEnum value1];");
   }
+
+  public void testKotlinGetProperty() throws IOException {
+    String translation = translateSourceFile(
+            "import com.mirego.interop.ConcreteClassWithConstructor;\n" +
+                    "@SuppressWarnings(\"unused\")\n" +
+                    "class Test {\n" +
+                    "public static void testProperties() {\n" +
+                    "\n" +
+                    "        final ConcreteClassWithConstructor concreteClassWithConstructor = new ConcreteClassWithConstructor(5);\n" +
+                    "        int propertyVar = concreteClassWithConstructor.getPropertyVar();\n" +
+                    "}\n" +
+                    "}",
+            "Test", "Test.m");
+    assertTranslation(translation, "jint propertyVar = [concreteClassWithConstructor propertyVar];");
+  }
+
+  public void testKotlinSetProperty() throws IOException {
+    String translation = translateSourceFile(
+            "import com.mirego.interop.ConcreteClassWithConstructor;\n" +
+                    "@SuppressWarnings(\"unused\")\n" +
+                    "class Test {\n" +
+                    "public static void testProperties() {\n" +
+                    "\n" +
+                    "        final ConcreteClassWithConstructor concreteClassWithConstructor = new ConcreteClassWithConstructor(5);\n" +
+                    "        concreteClassWithConstructor.setPropertyVar(2);\n" +
+                    "}\n" +
+                    "}",
+            "Test", "Test.m");
+    assertTranslation(translation, "[concreteClassWithConstructor setPropertyVar:2];");
+  }
 }


### PR DESCRIPTION
### Description and motivation

- Add support for Kotlin default getter/setter of properties in j2objc
- Custom kotlin getter/setter not yet supported

### Work done

- Getter/setter naturally working from previous work on KotlinMetadataUtil class
- Added unit tests in FunctionizerTests for Kotlin Getter and Setter. 

### Tasks

- Unit tests 

### Result

final int propertyVar = concreteClassWithConstructor.getPropertyVar();  

->  jint propertyVar = [concreteClassWithConstructor propertyVar];

concreteClassWithConstructor.setPropertyVar(2); -> [concreteClassWithConstructor setPropertyVar:2];
