### PR TITLE
Support kotlin object method without @jvmStatic Annotation

### DIFF
--- a/kotlin-interop-test-cases/src/commonMain/kotlin/test/objects/ObjectWithMethod.kt
+++ b/kotlin-interop-test-cases/src/commonMain/kotlin/test/objects/ObjectWithMethod.kt
@@ -4,6 +4,11 @@ import kotlin.jvm.JvmStatic
 import kotlin.js.JsName
 
 object ObjectWithMethod {
+
+    fun staticMethodWithoutParam(): String {
+        return "return"
+    }
+
     @JvmStatic
     fun staticMethodWithoutParamWithAnnotation(): String {
         return "return"

--- a/kotlin-native-tests/src/test/java/ObjectsTests.java
+++ b/kotlin-native-tests/src/test/java/ObjectsTests.java
@@ -53,4 +53,10 @@ public class ObjectsTests extends TestCase {
         WithObject withObject = new WithObject();
         assertEquals("objectString", withObject.main(NO_ARGS));
     }
+
+    @Test
+    public void testStaticMethodWithoutParams() {
+        StaticMethodWithoutParam staticMethodWithoutParam = new StaticMethodWithoutParam();
+        assertEquals("return", staticMethodWithoutParam.main(NO_ARGS));
+    }
 }

--- a/translator/src/main/java/com/google/devtools/j2objc/translate/Functionizer.java
+++ b/translator/src/main/java/com/google/devtools/j2objc/translate/Functionizer.java
@@ -746,15 +746,19 @@ public class Functionizer extends UnitTreeVisitor {
 
     String executableElementName = KotlinUtil.getKotlinElementName(element, nameTable);
     TypeMirror typeMirror = ElementUtil.getDeclaringClass(element).asType();
-    String nodeExpression = node.getExpression().toString();
+    Expression nodeExpression = node.getExpression();
 
     String instanceSelector;
     SimpleName executableExpression;
     if (ElementUtil.isStatic(element)) {
-      instanceSelector = NameTable.uncapitalize(nodeExpression);
+      instanceSelector = NameTable.uncapitalize(nodeExpression.toString());
+      executableExpression = new SimpleName(executableElementName);
+    } else if (KotlinUtil.isKotlinObjectWithoutJvmStaticAnnotation(nodeExpression)) {
+      FieldAccess fieldAccess = (FieldAccess)nodeExpression;
+      instanceSelector = NameTable.uncapitalize(fieldAccess.getExpression().toString());
       executableExpression = new SimpleName(executableElementName);
     } else {
-      instanceSelector = getCompanionObjectOrObjectInstanceSelector(nodeExpression);
+      instanceSelector = getCompanionObjectOrObjectInstanceSelector(nodeExpression.toString());
       executableExpression = new SimpleName(executableElementName + NameTable.capitalize(instanceSelector));
     }
     executableExpression.setTypeMirror(typeMirror);

--- a/translator/src/main/java/com/google/devtools/j2objc/util/KotlinUtil.java
+++ b/translator/src/main/java/com/google/devtools/j2objc/util/KotlinUtil.java
@@ -1,6 +1,7 @@
 package com.google.devtools.j2objc.util;
 
 import com.google.devtools.j2objc.ast.Expression;
+import com.google.devtools.j2objc.ast.FieldAccess;
 import com.google.devtools.j2objc.ast.TreeUtil;
 
 import javax.annotation.Nullable;
@@ -31,13 +32,16 @@ public final class KotlinUtil {
         LIST,
     }
 
+    private static final String JAVA_UTIL_LIST = "java.util.List";
+    private static final String KOTIN_JVM_INSTANCE_IDENTIFIER = "INSTANCE";
+
     public static KotlinWrappedTypes getKotlinType(TypeMirror type) {
         if (TypeUtil.isArray(type)) {
             return KotlinWrappedTypes.ARRAY;
         }
         TypeElement typeElement = TypeUtil.asTypeElement(type);
         if (typeElement != null) {
-            if (typeElement.getQualifiedName().contentEquals("java.util.List")) {
+            if (typeElement.getQualifiedName().contentEquals(JAVA_UTIL_LIST)) {
                 return KotlinWrappedTypes.LIST;
             }
         }
@@ -100,6 +104,14 @@ public final class KotlinUtil {
 
     public static boolean isKotlinCompanionObjectOrObject(KmClass kotlinMetaData) {
         return isCompanionObjectKmClass(kotlinMetaData) || isObjectKmClass(kotlinMetaData);
+    }
+
+    public static boolean isKotlinObjectWithoutJvmStaticAnnotation(Expression expression) {
+        if (expression instanceof FieldAccess) {
+            FieldAccess fieldAccess = (FieldAccess) expression;
+            return fieldAccess.getName().getIdentifier().equals(KOTIN_JVM_INSTANCE_IDENTIFIER);
+        }
+        return false;
     }
 
     private static boolean isEnumKmClass(KmClass kotlinMetaData) {

--- a/translator/src/test/java/com/google/devtools/j2objc/kotlin/ObjectsTest.java
+++ b/translator/src/test/java/com/google/devtools/j2objc/kotlin/ObjectsTest.java
@@ -1,13 +1,7 @@
 package com.google.devtools.j2objc.kotlin;
 
 import com.google.devtools.j2objc.GenerationTest;
-import com.mirego.interop.java.test.objects.StaticMethodWithGenericParamWithAnnotation;
-import com.mirego.interop.java.test.objects.StaticMethodWithListParamWithAnnotation;
-import com.mirego.interop.java.test.objects.StaticMethodWithStringParamWithAnnotation;
-import com.mirego.interop.java.test.objects.StaticMethodWithoutParamWithAnnotation;
-import com.mirego.interop.java.test.objects.WithCompanionObject;
-import com.mirego.interop.java.test.objects.WithNamedCompanionObject;
-import com.mirego.interop.java.test.objects.WithObject;
+import com.mirego.interop.java.test.objects.*;
 
 import java.io.IOException;
 import org.junit.Test;
@@ -80,5 +74,14 @@ public class ObjectsTest extends GenerationTest {
     String translation = translateJavaSourceFileForKotlinTest(className, testPackage, ".m");
 
     assertTranslation(translation, "[CommonClassWithObjectNamed named].objectString");
+  }
+
+  @Test
+  public void testStaticMethodWithoutParams() throws IOException {
+
+    String className = StaticMethodWithoutParam.class.getSimpleName();
+    String translation = translateJavaSourceFileForKotlinTest(className, testPackage, ".m");
+
+    assertTranslation(translation, "[[CommonObjectWithMethod objectWithMethod] staticMethodWithoutParam]");
   }
 }

--- a/translator/src/test/java/com/mirego/interop/java/test/objects/StaticMethodWithoutParam.java
+++ b/translator/src/test/java/com/mirego/interop/java/test/objects/StaticMethodWithoutParam.java
@@ -1,0 +1,10 @@
+package com.mirego.interop.java.test.objects;
+
+import com.mirego.interop.kotlin.test.objects.ObjectWithMethod;
+
+public class StaticMethodWithoutParam {
+
+    public static String main(String[] args) {
+        return ObjectWithMethod.INSTANCE.staticMethodWithoutParam();
+    }
+}


### PR DESCRIPTION
This was needed to prevent going into external library that might now have added the annotation on static methods.